### PR TITLE
Fix _create_or_patch_scmbrc to work on OS X (10.7)

### DIFF
--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -26,7 +26,7 @@ update_scm_breeze() {
 
 # Create '~/.*.scmbrc' files, or attempt to patch them if passed a previous revision
 _create_or_patch_scmbrc() {
-  patchfile=$(mktemp)
+  patchfile=$(mktemp -t tmp.XXXXXXXXXX)
   for scm in git; do
     # Create file from example if it doesn't already exist
     if ! [ -e "$HOME/.$scm.scmbrc" ]; then


### PR DESCRIPTION
On OS X's version of mktemp the -t parameter is manditory -
see http://developer.apple.com/library/mac/#DOCUMENTATION/Darwin/Reference/ManPages/man1/mktemp.1.html
