### PR TITLE
Add zsh/shwordsplit compatibility for git_status_shortcuts

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -17,6 +17,7 @@
 # 1 || staged,  2 || unmerged,  3 || unstaged,  4 || untracked
 # --------------------------------------------------------------------
 git_status_shortcuts() {
+  zsh_compat # Ensure shwordsplit is on for zsh
   git_clear_vars
   # Run ruby script, store output
   cmd_output=$(/usr/bin/env ruby "$scmbDir/lib/git/status_shortcuts.rb" $@)
@@ -32,6 +33,7 @@ git_status_shortcuts() {
 
   # Print status
   echo "$cmd_output" | grep -v '@@filelist@@::'
+  zsh_reset # Reset zsh environment to default
 }
 
 


### PR DESCRIPTION
Necessary so that IFS works as expected.  I think this worked originally in the shell-based status shortcuts, but got lost on switching to the ruby implementation.
