### PR TITLE
Fix the install script outputting '-e' to rc files on OS X

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ exec_string='[[ -s "$HOME/.scm_breeze/scm_breeze.sh" ]] && . "$HOME/.scm_breeze/
 # Add line to bashrc and zshrc if not already present.
 for rc in bashrc zshrc; do
   if [[ -s "$HOME/.$rc" ]] && ! grep -q "$exec_string" "$HOME/.$rc"; then
-    echo -e "\n$exec_string" >> "$HOME/.$rc"
+    echo "\n$exec_string" >> "$HOME/.$rc"
     echo "== Added SCM Breeze to '~/.$rc'"
   fi
 done


### PR DESCRIPTION
OS X's default shell doesn't like "echo -e foo" - it actually outputs "-e foo".

Fortunately, we don't actually use escape characters in the install script string, so -e is unnecessary.
