### PR TITLE
Fix switching to repositories with spaces or other special characters in their path

### DIFF
--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -91,7 +91,7 @@ function git_index() {
       # Go to our base path
       if [ -n "$base_path" ]; then
         unset IFS
-        eval cd "$base_path"   # eval turns ~ into $HOME
+        eval cd \"$base_path\"   # eval turns ~ into $HOME
         # Run git callback (either update or show changes), if we are in the root directory
         if [ -z "${sub_path%/}" ]; then _git_index_update_or_status; fi
       else


### PR DESCRIPTION
Example:

Running `s my\ repository` would result in my shell complaining that "my" is not in the current pwd. I was also having issues with repositories with apostrophes in the name. Escaping the quotes around the variable fixes both of these issues.
