### PR TITLE
Don't export 'i' and 'cmd_output' as global vars

### DIFF
--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -18,6 +18,7 @@ git_status_shortcuts() {
   zsh_compat # Ensure shwordsplit is on for zsh
   IFS=$'\n'
   local git_status="$(git status --porcelain 2> /dev/null)"
+  local i
 
   if [ -n "$git_status" ] && [[ $(echo "$git_status" | wc -l) -le $gs_max_changes ]]; then
     unset stat_file; unset stat_col; unset stat_msg; unset stat_grp; unset stat_x; unset stat_y

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -20,7 +20,7 @@ git_status_shortcuts() {
   zsh_compat # Ensure shwordsplit is on for zsh
   git_clear_vars
   # Run ruby script, store output
-  cmd_output=$(/usr/bin/env ruby "$scmbDir/lib/git/status_shortcuts.rb" $@)
+  local cmd_output=$(/usr/bin/env ruby "$scmbDir/lib/git/status_shortcuts.rb" $@)
   # Print debug information if $scmbDebug = "true"
   if [ "$scmbDebug" = "true" ]; then
     printf "status_shortcuts.rb output => \n$cmd_output\n------------------------\n"
@@ -161,6 +161,7 @@ exec_git_expand_args() { $(git_expand_args "$@"); }
 
 # Clear numbered env variables
 git_clear_vars() {
+  local i
   for (( i=1; i<=$gs_max_changes; i++ )); do
     # Stop clearing after first empty var
     if [[ -z "$(eval echo "\$$git_env_char$i")" ]]; then break; fi


### PR DESCRIPTION
Hi - I ran into a problem when trying to run something along the lines of `for i in foo bar; do echo $i; done`, which doesn't work as expected when 'i' has previously been exported from one of scm_breeze's for loops.  This patch ought to fix that, as well as cleaning up the only other global I could find (cmd_output).
