### PR TITLE
Quote cmd_output to fix zsh compatibility

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -20,7 +20,7 @@ git_status_shortcuts() {
   zsh_compat # Ensure shwordsplit is on for zsh
   git_clear_vars
   # Run ruby script, store output
-  local cmd_output=$(/usr/bin/env ruby "$scmbDir/lib/git/status_shortcuts.rb" $@)
+  local cmd_output="$(/usr/bin/env ruby "$scmbDir/lib/git/status_shortcuts.rb" $@)"
   # Print debug information if $scmbDebug = "true"
   if [ "$scmbDebug" = "true" ]; then
     printf "status_shortcuts.rb output => \n$cmd_output\n------------------------\n"


### PR DESCRIPTION
Sorry - I think I broke zsh compatibility in that last commit...
AFAICT, zsh treats the assignment in `foo=$(blah)` and `local foo=$(blah)` differently... the latter needs wrapping in quotes to ensure it's kept as a single 'token'.
