### PR TITLE
Avoid bash's variable unbound error

### DIFF
--- a/lib/git/aliases_and_bindings.sh
+++ b/lib/git/aliases_and_bindings.sh
@@ -38,7 +38,7 @@ _git
 # Usage: __git_alias <alias> <command_prefix> <command>
 __git_alias () {
   if [ -n "$1" ]; then
-    local alias_str="$1"; local cmd_prefix="$2"; local cmd="$3"; local cmd_args=" $4"
+    local alias_str="$1"; local cmd_prefix="$2"; local cmd="$3"; local cmd_args=" ${4-}"
     alias $alias_str="$cmd_prefix $cmd$cmd_args"
     if [ "$shell" = "bash" ]; then
       __define_git_completion $alias_str $cmd

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -22,7 +22,7 @@ git_status_shortcuts() {
   # Run ruby script, store output
   local cmd_output="$(/usr/bin/env ruby "$scmbDir/lib/git/status_shortcuts.rb" $@)"
   # Print debug information if $scmbDebug = "true"
-  if [ "$scmbDebug" = "true" ]; then
+  if [ "${scmbDebug:-}" = "true" ]; then
     printf "status_shortcuts.rb output => \n$cmd_output\n------------------------\n"
   fi
   if [[ -z "$cmd_output" ]]; then
@@ -31,18 +31,18 @@ git_status_shortcuts() {
   fi
   # Fetch list of files from last line of script output
   files="$(echo "$cmd_output" | \grep '@@filelist@@::' | sed 's%@@filelist@@::%%g')"
-  if [ "$scmbDebug" = "true" ]; then echo "filelist => $files"; fi
+  if [ "${scmbDebug:-}" = "true" ]; then echo "filelist => $files"; fi
   # Export numbered env variables for each file
   IFS="|"
   local e=1
   for file in $files; do
     export $git_env_char$e="$file"
-    if [ "$scmbDebug" = "true" ]; then echo "Set \$$git_env_char$e  => $file"; fi
+    if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$git_env_char$e  => $file"; fi
     let e++
   done
   IFS=$' \t\n'
 
-  if [ "$scmbDebug" = "true" ]; then echo "------------------------"; fi
+  if [ "${scmbDebug:-}" = "true" ]; then echo "------------------------"; fi
   # Print status
   echo "$cmd_output" | \grep -v '@@filelist@@::'
   zsh_reset # Reset zsh environment to default
@@ -164,8 +164,7 @@ git_clear_vars() {
   local i
   for (( i=1; i<=$gs_max_changes; i++ )); do
     # Stop clearing after first empty var
-    if [[ -z "$(eval echo "\$$git_env_char$i")" ]]; then break; fi
-    unset $git_env_char$i
+    if [[ -z "$(eval echo "\${$git_env_char$i:-}")" ]]; then break; fi
   done
 }
 


### PR DESCRIPTION
When I use bash's option nounset (It can be enable by "set -o nounset"),
running commands of scm_breeze get errors like below.
  "-bash: e4: unbound variable"
  "-bash: scmbDebug: unbound variable"

I just avoid from error situation by make variable empty if specific variable unset.

If you think proper solution for this error situation. please notice me.
thank you.
