### PR TITLE
Symbolic link in $GIT_REPO_DIR

### DIFF
--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -123,7 +123,7 @@ _git_index_dirs_without_home() {
 function _find_git_repos() {
   # Find all unarchived projects
   IFS=$'\n'
-  for repo in $(find "$GIT_REPO_DIR" -maxdepth 4 -name ".git" -type d \! -wholename '*/archive/*'); do
+  for repo in $(find -L "$GIT_REPO_DIR" -maxdepth 4 -name ".git" -type d \! -wholename '*/archive/*'); do
     echo ${repo%/.git}          # Return project folder, with trailing ':'
     _find_git_submodules $repo  # Detect any submodules
   done


### PR DESCRIPTION
I have symbolic link ~/code to my projects directory.
After successful installation I try to run command "с --rebuild" but nothing was founded.
Default beahaviour find command (from man): Never follow symbolic links.
Adding option "-L" fix that.
