### PR TITLE
bugfix for #33. don't add a trailing space when creating aliases

### DIFF
--- a/lib/git/aliases_and_bindings.sh
+++ b/lib/git/aliases_and_bindings.sh
@@ -38,8 +38,8 @@ _git
 # Usage: __git_alias <alias> <command_prefix> <command>
 __git_alias () {
   if [ -n "$1" ]; then
-    local alias_str="$1"; local cmd_prefix="$2"; local cmd="$3"; local cmd_args=" ${4-}"
-    alias $alias_str="$cmd_prefix $cmd$cmd_args"
+    local alias_str="$1"; local cmd_prefix="$2"; local cmd="$3"; local cmd_args="${4-}"
+    alias $alias_str="$cmd_prefix $cmd${cmd_args:+ }$cmd_args"
     if [ "$shell" = "bash" ]; then
       __define_git_completion $alias_str $cmd
       complete -o default -o nospace -F _git_"$alias_str"_shortcut $alias_str


### PR DESCRIPTION
this commit only adds the space if there are additional arguments
