### PR TITLE
Avoid infinite loop in __gs_relative_path when $(PWD) contains a symlink...

### DIFF
--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -128,7 +128,8 @@ _gs_output_file_group() {
       relative="${stat_file[$i]}"
     else
       dest="$project_root/${stat_file[$i]}"
-      relative="$(_gs_relative_path "$PWD" "$dest" )"
+		local pwd=$(readlink -f "$PWD")
+		relative="$(_gs_relative_path "$pwd" "$dest" )"
     fi
 
     if [[ $f -gt 10 && $e -lt 10 ]]; then local pad=" "; else local pad=""; fi   # (padding)


### PR DESCRIPTION
[Resending pull request - I had closed my previous request because I thought "readlink -f" would fall over when given a non-symlinked path, but it handles it just fine]

When $(PWD) has a symlinked directory, in function __gs_relative_path, the comparison becomes between an absolute path and symlinked directory, resulting in the while loop never terminating, and "gs" for example getting stuck forever. The patch first resolves $(PWD) to an absolute path.

For example I have a ~/work directory that maps to the base of all my sources, and I typically do |cd ~/work| to go there.
