### PR TITLE
Use vared in zsh instead of read.

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -175,9 +175,7 @@ theirs(){ _git_resolve_merge_conflict "their" "$@"; }
 git_commit_prompt() {
   local commit_msg
   if [[ $shell == "zsh" ]]; then
-    # zsh 'read' is weak. If you know how to make this better, please send a pull request.
-    # (Bash 'read' supports prompt, arrow keys, home/end, up through bash history, etc.)
-    echo -n "Commit Message: "; read commit_msg
+    vared -h -p "Commit Message: " commit_msg
   else
     read -r -e -p "Commit Message: " commit_msg
   fi


### PR DESCRIPTION
This change seems to do what you want.  It passes ! and \ untouched, it gets history from the shell and it uses the zsh line editor for arrow keys and home/end.
