### PR TITLE
ZSH and OS X compatibility

### DIFF
--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -92,7 +92,6 @@ else
   _abs_path_command="readlink -f"
 fi
 
-if [ -n "$_ll_command" ]; then
   # Function wrapper around 'll'
   # Adds numbered shortcuts to output of ls -l, just like 'git status'
   unalias ll > /dev/null 2>&1; unset -f ll > /dev/null 2>&1
@@ -166,7 +165,6 @@ EOF
     done
     IFS="$OLDIFS"
   }
-fi
 
 # Setup aliases
 alias ll="exec_scmb_expand_args ls_with_file_shortcuts"


### PR DESCRIPTION
Hello!
This pull request addresses some minor issues with the shell_shortcuts.sh.
- I am on OS X and use GNU coreutils, so I have GNU ls and readlink. I updated the code to check the actual commands (like, say, duck typing) and not architecture.
- the ls_with_file_shortcuts function was failing due on ZSH due to missing sh_word_split option
- ls_with_file_shortcuts was failing on ZSH due to eval interpreting the $_ll_command as a whole command, and of course a file named "ls -G" was not found in path :)

Please feel free to comment/amend my code as you will.
