### PR TITLE
Pick the first git in case there are multiple

### DIFF
--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -13,7 +13,7 @@ disable_nullglob() { if [ $shell = "zsh" ]; then unsetopt NULL_GLOB; else shopt 
 _alias(){ alias "$@" 2> /dev/null; }
 
 if [ $shell = "zsh" ]; then
-  export GIT_BINARY=$(type -p git | sed 's/git is //')
+  export GIT_BINARY=$(type -p git | sed 's/git is //' | head -1)
 else
   export GIT_BINARY=$(type -P git)
 fi


### PR DESCRIPTION
If you have multiple gits installed, such as /usr/bin/git from apple and /usr/local/bin/git from homebrew, scm_breeze will complain with an error:

`scm_breeze.sh:export:16: not valid in this context: /usr/bin/git`

To fix it, I just took the `head -1` to ensure the first git is used. This works fine with just one git as well because head always returns the first line anyway.
