### PR TITLE
Add 'gdw' for git diff --word-diff

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -47,6 +47,7 @@ git_reset_hard_alias="grsh"
 git_rm_alias="grm"
 git_blame_alias="gbl"
 git_diff_alias="gd"
+git_diff_word_alias="gdw"
 git_diff_cached_alias="gdc"
 # 3. Standard commands
 git_clone_alias="gcl"

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -94,6 +94,7 @@ if [ "$git_setup_aliases" = "yes" ]; then
   __git_alias "$git_rm_alias"          "git" "rm"
   __git_alias "$git_blame_alias"       "git" "blame"
   __git_alias "$git_diff_alias"        "git" "diff"
+  __git_alias "$git_diff_word_alias"   "git" "diff" "--word-diff"
   __git_alias "$git_diff_cached_alias" "git" "diff" "--cached"
   __git_alias "$git_add_patch_alias"   "git" "add" "-p"
   # Custom default format for git log


### PR DESCRIPTION
- Sometimes helpful to see changes inline
- Potential to tweak further with better regex (maybe detect similar char types so diff can be more granular)
