### PR TITLE
Fix for numbered directories or files

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -121,7 +121,11 @@ scmb_expand_args() {
   for arg in "$@"; do
     if [[ "$arg" =~ ^[0-9]+$ ]] ; then      # Substitute $e{*} variables for any integers
       if [ "$first" -eq 1 ]; then first=0; else printf '\t'; fi
-      eval printf '%s' "\"\$$git_env_char$arg\""
+      if [ -e "$arg" ]; then 
+        printf '%s' "$arg"
+      else
+        eval printf '%s' "\"\$$git_env_char$arg\""
+      fi
     elif [[ "$arg" =~ ^[0-9]+-[0-9]+$ ]]; then           # Expand ranges into $e{*} variables
 
       for i in $(eval echo {${arg/-/..}}); do


### PR DESCRIPTION
This commit fixes some odd behavior for numbered files and directories. Even if the environment variables is undefined cd'ing into a numbered directory is not possible. 

Below see a short shell transcript showing the issue from a plan bash shell.

```
bash-3.2$ pwd
/tmp/test
bash-3.2$ git init
Initialized empty Git repository in /private/tmp/test/.git/
bash-3.2$ ga
bash: ga: command not found
bash-3.2$ mkdir 200
bash-3.2$ cd 200
bash-3.2$ pwd
/tmp/test/200
bash-3.2$ cd ..
bash-3.2$ source ~/.scm_breeze/scm_breeze.sh
bash-3.2$ ga
Usage: ga <file>  => git add <file>
       ga 1       => git add $e1
       ga 2-4    => git add $e2 $e3 $e4
       ga 2 5-7  => git add $e2 $e5 $e6 $e7

Note: Deleted files will also be staged using this shortcut.
      To turn off this behaviour, change the 'auto_remove' option.
bash-3.2$ cd 200
bash-3.2$ pwd
/Users/grund
```

As you can see, I start in a blank folder and initialize a new git repository, then I create a folder called 200 and cd into it. After sourcing the scm_breeze.sh script I can no cd into the directory if it is the only path component.

This patch fixes this behaviour by performing a check if the file or folder exists before applying the substitution for the environment variable for wrapped commands.
