### PR TITLE
Fix gb -D expansion

### DIFF
--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -15,7 +15,7 @@ function _scmb_git_branch_shortcuts {
   fail_if_not_git_repo || return 1
   # Fall back to normal git branch, if any unknown args given
   if [[ -n "$@" ]] && [[ "$@" != "-a" ]]; then
-    $_git_cmd branch "$@"
+    exec_scmb_expand_args $_git_cmd branch "$@"
     return 1
   fi
 


### PR DESCRIPTION
Here is a simple pseudo testcase:
Before:

``` shell
~/work/test% gb                                    
* [1] master
~/work/test% gco -b test
Switched to a new branch 'test'
~/work/test% gb
  [1] master
* [2] test
~/work/test% gco 1
Switched to branch 'master'
~/work/test% gb -D 2
error: branch '2' not found.
```

After:

``` shell
~/work/test% gb                                    
* [1] master
~/work/test% gco -b test
Switched to a new branch 'test'
~/work/test% gb
  [1] master
* [2] test
~/work/test% gco 1
Switched to branch 'master'
~/work/test% gb -D 2
Deleted branch test (was 8c5a00b).
```
