### PR TITLE
Git stash aliases

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -84,6 +84,9 @@ git_log_stat_alias="gls"
 git_log_graph_alias="glg"
 git_show_alias="gsh"
 git_show_summary="gsm"  # (gss taken by git status short)
+git_stash_alias="gash"
+git_stash_apply_alias="gasha"
+git_stash_list_alias="gashl"
 git_tag_alias="gt"
 
 

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -121,6 +121,9 @@ if [ "$git_setup_aliases" = "yes" ]; then
   __git_alias "$git_cherry_pick_alias" "git" 'cherry-pick'
   __git_alias "$git_show_alias" "git" 'show'
   __git_alias "$git_show_summary" "git" 'show' '--summary'
+  __git_alias "$git_stash_alias" "git" 'stash'
+  __git_alias "$git_stash_apply_alias" "git" 'stash' 'apply'
+  __git_alias "$git_stash_list_alias" "git" 'stash' 'list'
   __git_alias "$git_tag_alias" "git" 'tag'
 
 


### PR DESCRIPTION
Using `gash` as the base alias, since `gsh` is taken by `git show`
