### PR TITLE
Using git rev-parse --show-toplevel to find repo root

### DIFF
--- a/lib/git/status_shortcuts.rb
+++ b/lib/git/status_shortcuts.rb
@@ -20,7 +20,7 @@
 # # groups => 1: staged, 2: unmerged, 3: unstaged, 4: untracked
 # --------------------------------------------------------------------
 
-@project_root = File.exist?(".git") ? Dir.pwd : `\git rev-parse --git-dir 2> /dev/null`.sub(/\/\.git$/, '').strip
+@project_root = File.exist?(".git") ? Dir.pwd : `\git rev-parse --show-toplevel 2> /dev/null`.strip
 
 @git_status = `\git status --porcelain 2> /dev/null`
 


### PR DESCRIPTION
Fixes #104

--show-toplevel
Show the absolute path of the top-level directory.
https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
