### PR TITLE
Add git merge to the expanded numeric commands

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -26,7 +26,7 @@ if type hub > /dev/null 2>&1; then export _git_cmd="hub"; fi
 function git(){
   # Only expand args for git commands that deal with paths or branches
   case $1 in
-    checkout|commit|rm|blame|diff|add|log|rebase|reset)
+    checkout|commit|rm|blame|diff|add|log|rebase|reset|merge)
       exec_scmb_expand_args "$_git_cmd" "$@";;
     branch)
       _scmb_git_branch_shortcuts "${@:2}";;


### PR DESCRIPTION
Hello,

i was a little bit confused that was no **git merge** commands be expanded. After i add the merge command to the expanded commands. I was able to use git merge with numbers :)

I have tested it with single and more single numbers and it worked good.

Objections?
