### PR TITLE
Add note about other aliases.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,11 @@ $ ge echo 1-3
 ```
 
 
+### Other shortcuts
+
+SCM Breeze adds a total of 76 aliases to your shell. Use `list_aliases` to view all the aliases and their corresponding commands.
+
+
 ## Keyboard bindings
 
 Some of my most common git commands are `git add` and `git commit`, so I wanted these


### PR DESCRIPTION
I was looking for documentation about all the commands that SCM Breeze adds. I managed to find the `list_aliases` command by reading the code. I think most users would find this useful, so it ought to be documented.
