### PR TITLE
Fix upcoming Git 2.0 breaking change to `git add -A`.

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -148,7 +148,7 @@ if [ "$git_setup_aliases" = "yes" ]; then
   _alias $git_commit_no_msg_alias='git commit -C HEAD'
   _alias $git_log_stat_alias='git log --stat --max-count=5'
   _alias $git_log_graph_alias='git log --graph --max-count=5'
-  _alias $git_add_all_alias='git add -A'
+  _alias $git_add_all_alias='git add --all .'
 fi
 
 

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -233,7 +233,7 @@ git_commit_all() {
       local appending=" | \033[0;36mappending '\033[1;36m$APPEND\033[0;36m' to commit message.\033[0m"
     fi
     echo -e "\033[0;33mCommitting all files (\033[0;31m$changes\033[0;33m)\033[0m$appending"
-    git_commit_prompt "git add -A"
+    git_commit_prompt "git add --all ."
   else
     echo "# No changed files to commit."
   fi


### PR DESCRIPTION
Using SCM Breeze right now, the ctrl-X+space shortcut (which calls the git_commit_all shell status shortcut) triggers this message:

```
warning: The behavior of 'git add --all (or -A)' with no path argument from a
subdirectory of the tree will change in Git 2.0 and should not be used anymore.
To add content for the whole tree, run:

  git add --all :/
  (or git add -A :/)

To restrict the command to the current directory, run:

  git add --all .
  (or git add -A .)

With the current Git version, the command is restricted to the current directory.
```

I think these fix the two `-A` flag issues. Went with the safer, more normal option. Works in my browser for this commit.
