### PR TITLE
Don't show oldname -> newname for unstaged modifications

### DIFF
--- a/lib/git/status_shortcuts.rb
+++ b/lib/git/status_shortcuts.rb
@@ -127,7 +127,12 @@ end
   @stat_hash[group] << {:msg => msg, :col => col, :file => file} if msg
 
   # Work tree modification states
-  if y == "M"
+  if x == "R" && y == "M"
+    # Extract the second file name from the format x -> y
+    quoted, unquoted = /^(?:"(?:[^"\\]|\\.)*"|[^"].*) -> (?:"((?:[^"\\]|\\.)*)"|(.*[^"]))$/.match(file)[1..2]
+    renamed_file = quoted || unquoted
+    @stat_hash[:unstaged] << {:msg => "  modified", :col => :mod, :file => renamed_file}  
+  elsif x != "R" && y == "M"
     @stat_hash[:unstaged] << {:msg => "  modified", :col => :mod, :file => file}
   elsif y == "D" && x != "D" && x != "U"
     # Don't show deleted 'y' during a merge conflict.


### PR DESCRIPTION
I found a way to fix issue https://github.com/ndbroadbent/scm_breeze/issues/144.

This changes the output of git status from

```
# On branch: master  |  +1  |  [*] => $e*
#
➤ Changes to be committed
#
#        renamed: [1] "foo bar" -> test 
#
➤ Changes not staged for commit
#
#       modified: [2] "foo bar" -> test  
#
```

to

```
# On branch: master  |  +1  |  [*] => $e*
#
➤ Changes to be committed
#
#        renamed: [1] "foo bar" -> test 
#
➤ Changes not staged for commit
#
#       modified: [2] test 
#
```

This enables adding the modifications via `git add 2`.
