### PR TITLE
_create_or_patch_scmbrc is not noclobber safe

### DIFF
--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -48,7 +48,7 @@ _create_or_patch_scmbrc() {
     # If file exists, attempt to update it with any new settings
     elif [ -n "$1" ]; then
       # Create diff of example file, substituting example file for user's config.
-      git diff $1 "$prefix""scmbrc.example" | sed "s/$prefix""scmbrc.example/.$prefix""scmbrc/g" > $patchfile
+      git diff $1 "$prefix""scmbrc.example" | sed "s/$prefix""scmbrc.example/.$prefix""scmbrc/g" >| $patchfile
       if [ -s $patchfile ]; then  # If patchfile is not empty
         cd "$HOME"
         # If the patch cannot be applied cleanly, show the updates and tell user to update file manually.


### PR DESCRIPTION
```
draistrickmini:~/.scm_breeze(master)%% set -o noclobber
draistrickmini:~/.scm_breeze(master)%% update_scm_breeze
From git://github.com/ndbroadbent/scm_breeze
 * branch            master     -> FETCH_HEAD
Current branch master is up to date.
-bash: /var/folders/lh/pq0p3b310135b42_9b7mmybc0000z8/T/tmp.XXXXXXXXXX.rGcYfnaw: cannot overwrite existing file
-bash: /var/folders/lh/pq0p3b310135b42_9b7mmybc0000z8/T/tmp.XXXXXXXXXX.rGcYfnaw: cannot overwrite existing file
draistrickmini:~/.scm_breeze(master)%% set +o noclobber
draistrickmini:~/.scm_breeze(master)%% update_scm_breeze
From git://github.com/ndbroadbent/scm_breeze
 * branch            master     -> FETCH_HEAD
Current branch master is up to date.
```

Easily resolved by overriding noclobber when we write out the patch file with >| instead of >

(...another solution might be to use a more unique tmpfile at https://github.com/ndbroadbent/scm_breeze/blob/master/lib/scm_breeze.sh#L41 to avoid the need to clobber, but I didnt verify that.

tested locally with bash, and a quick zsh verification of >| functionality with 5.0.2
