### PR TITLE
add a bit more detail around install.sh in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -287,7 +287,7 @@ git clone git://github.com/ndbroadbent/scm_breeze.git ~/.scm_breeze
 source ~/.bashrc   # or source ~/.zshrc
 ```
 
-The install script just adds the following line to your `.bashrc` or `.zshrc`:
+The install script creates required default configs and adds the following line to your `.bashrc` or `.zshrc`:
 
 `[ -s "$HOME/.scm_breeze/scm_breeze.sh" ] && source "$HOME/.scm_breeze/scm_breeze.sh"`
 


### PR DESCRIPTION
install.sh is really required, you can't just clone source and go.

if you do, you never get any aliases, because you never get a .git.scmbrc file....

I found this out by skipping it, since I was building it into my config automation (so it just shows up everywhere), and simply did if ! clone ; source ....and found the environment broken. :)
