### PR TITLE
`gh` is the new `hub`

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -20,7 +20,7 @@ unset -f git > /dev/null 2>&1
 export _git_cmd="$(\which git)"
 # Wrap git with the 'hub' github wrapper, if installed (https://github.com/defunkt/hub)
 if type hub > /dev/null 2>&1; then export _git_cmd="hub"; fi
-
+if type gh  > /dev/null 2>&1; then export _git_cmd="gh"; fi
 
 # Create 'git' function that calls hub if defined, and expands all numeric arguments
 function git(){


### PR DESCRIPTION
`gh` is the new `hub`, rewritten to be fast and efficient.
http://owenou.com/gh/

It has been adopted by GitHub themselves and will replace `hub` entirely:
https://github.com/github/hub/issues/475

This patch simply checks for `gh` as a possible `_git_cmd` in addition to 
hub, restoring scm_breeze functionality for people who have switched to gh.
