### PR TITLE
BUGFIX: make `git_clear_vars()` actually clear variables

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -166,7 +166,12 @@ git_clear_vars() {
   local i
   for (( i=1; i<=$gs_max_changes; i++ )); do
     # Stop clearing after first empty var
-    if [[ -z "$(eval echo "\${$git_env_char$i:-}")" ]]; then break; fi
+    local env_var_i=${git_env_char}${i}
+    if [[ -z "$(eval echo "\${$env_var_i:-}")" ]]; then
+      break
+    else
+      unset $env_var_i
+    fi
   done
 }
 


### PR DESCRIPTION
The current `git_clear_vars()` method appears to have iterated over all the existing set variable correctly, but seemingly never actually cleared them.  This fixes that behavior as best I can tell.

(That said, the extra variables weren't really hurting anybody before this fix, so maybe another option is the entire function should be deprecated to reduce the amount of operations a `gs` has to do in the interest of speed. Let me know what you prefer!)
