### PR TITLE
Add aliases for "git submodule update --init" and "git submodule update --init --recursive"

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -95,6 +95,8 @@ git_stash_apply_alias="gasha"
 git_stash_pop_alias="gashp"
 git_stash_list_alias="gashl"
 git_tag_alias="gt"
+git_submodule_update_alias="gsu"
+git_submodule_update_rec_alias="gsur"
 # Hub aliases (https://github.com/github/hub)
 git_pull_request_alias="gpr"
 

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -137,6 +137,8 @@ if [ "$git_setup_aliases" = "yes" ]; then
   __git_alias "$git_stash_pop_alias"                'git' 'stash' 'pop'
   __git_alias "$git_stash_list_alias"               'git' 'stash' 'list'
   __git_alias "$git_tag_alias"                      'git' 'tag'
+  __git_alias "$git_submodule_update_alias"         'git' 'submodule' 'update' '--init'
+  __git_alias "$git_submodule_update_rec_alias"     'git' 'submodule' 'update' '--init' '--recursive'
 
 
   # Compound/complex commands


### PR DESCRIPTION
Added `--init` to both, as I can't think of many cases when you explicitly _don't_ want `--init`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ndbroadbent/scm_breeze/159)
<!-- Reviewable:end -->
