### PR TITLE
Expand arguments for git difftool.

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -26,7 +26,7 @@ if type gh  > /dev/null 2>&1; then export _git_cmd="gh"; fi
 function git(){
   # Only expand args for git commands that deal with paths or branches
   case $1 in
-    commit|blame|add|log|rebase|merge)
+    commit|blame|add|log|rebase|merge|difftool)
       exec_scmb_expand_args "$_git_cmd" "$@";;
     checkout|diff|rm|reset)
       exec_scmb_expand_args --relative "$_git_cmd" "$@";;


### PR DESCRIPTION
Having difftool included in the commands that are expanded by default would make it easier to use an external diffing tool with scm_breeze.