### PR TITLE
Bump git index depth to 5 for golang src structure

### DIFF
--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -127,7 +127,7 @@ _git_index_dirs_without_home() {
 function _find_git_repos() {
   # Find all unarchived projects
   IFS=$'\n'
-  for repo in $(find -L "$GIT_REPO_DIR" -maxdepth 4 -name ".git" -type d \! -wholename '*/archive/*'); do
+  for repo in $(find -L "$GIT_REPO_DIR" -maxdepth 5 -name ".git" -type d \! -wholename '*/archive/*'); do
     echo ${repo%/.git}          # Return project folder, with trailing ':'
     _find_git_submodules $repo  # Detect any submodules
   done


### PR DESCRIPTION
Had to do this to pick up my golang code with `c --rebuild`. Think 5 is still pretty reasonable.