### PR TITLE
make tests independent of bin locations

### DIFF
--- a/test/lib/git/shell_shortcuts_test.sh
+++ b/test/lib/git/shell_shortcuts_test.sh
@@ -33,9 +33,9 @@ oneTimeSetUp() {
   # Test functions
   function ln() { ln $@; }
   # Test aliases
-  alias mv="nocorrect mv"
-  alias rm="rm --option"
-  alias sed="sed"
+  alias mv="nocorrect /bin/mv"
+  alias rm="/bin/rm --option"
+  alias sed="/bin/sed"
   # Test already wrapped commands
   alias cat="exec_scmb_expand_args /bin/cat"
 

--- a/test/lib/git/shell_shortcuts_test.sh
+++ b/test/lib/git/shell_shortcuts_test.sh
@@ -33,11 +33,11 @@ oneTimeSetUp() {
   # Test functions
   function ln() { ln $@; }
   # Test aliases
-  alias mv="nocorrect /bin/mv"
-  alias rm="/bin/rm --option"
-  alias sed="/bin/sed"
+  alias mv="nocorrect $(which mv)"
+  alias rm="$(which rm) --option"
+  alias sed="$(which sed)"
   # Test already wrapped commands
-  alias cat="exec_scmb_expand_args /bin/cat"
+  alias cat="exec_scmb_expand_args $(which cat)"
 
   # Run shortcut wrapping
   source "$scmbDir/lib/git/shell_shortcuts.sh"
@@ -59,11 +59,11 @@ assertAliasEquals(){
 #-----------------------------------------------------------------------------
 
 test_shell_command_wrapping() {
-  assertAliasEquals "exec_scmb_expand_args /bin/rm --option"  "rm"
-  assertAliasEquals "exec_scmb_expand_args nocorrect /bin/mv" "mv"
-  assertAliasEquals "exec_scmb_expand_args /bin/sed"          "sed"
-  assertAliasEquals "exec_scmb_expand_args /bin/cat"          "cat"
-  assertAliasEquals "exec_scmb_expand_args builtin cd"        "cd"
+  assertAliasEquals "exec_scmb_expand_args $(which rm) --option"  "rm"
+  assertAliasEquals "exec_scmb_expand_args nocorrect $(which mv)" "mv"
+  assertAliasEquals "exec_scmb_expand_args $(which sed)"          "sed"
+  assertAliasEquals "exec_scmb_expand_args $(which cat)"          "cat"
+  assertAliasEquals "exec_scmb_expand_args builtin cd"            "cd"
   assertIncludes    "$(declare -f ln)" "ln ()"
   assertIncludes    "$(declare -f ln)" "exec_scmb_expand_args __original_ln"
 }


### PR DESCRIPTION
On my system (Arch Linux), the commands {mv,rm,sed} live under
`/usr/bin`, not under `/bin`. So the tests were failing.

This commit hard-codes the initial paths to make the tests independent
on their real paths.