### PR TITLE
Fix tests

### DIFF
--- a/test/lib/git/shell_shortcuts_test.sh
+++ b/test/lib/git/shell_shortcuts_test.sh
@@ -21,6 +21,13 @@ fi
 source "$scmbDir/test/support/test_helper.sh"
 source "$scmbDir/lib/scm_breeze.sh"
 
+bin_path() {
+  if [ -n "${ZSH_VERSION:-}" ];
+    then where "$@" | tail -1
+    else which "$@"
+  fi
+}
+
 # Setup
 #-----------------------------------------------------------------------------
 oneTimeSetUp() {
@@ -35,10 +42,10 @@ oneTimeSetUp() {
 
   # Before aliasing, get original locations so we can compare them in the test
   unalias mv rm sed cat 2>/dev/null
-  export mv_path="$(which mv)"
-  export rm_path="$(which rm)"
-  export sed_path="$(which sed)"
-  export cat_path="$(which cat)"
+  export mv_path="$(bin_path mv)"
+  export rm_path="$(bin_path rm)"
+  export sed_path="$(bin_path sed)"
+  export cat_path="$(bin_path cat)"
 
   # Test aliases
   alias mv="nocorrect $mv_path"


### PR DESCRIPTION
# What I've done

I fixed the failing alias'ing tests by wrapping the differences between zsh and bash concerning the output of the `which` command inside a `bin_path()` function. I also fixed what appears to be improved sorting behavior concerning 1 & 2 digit numbers.

# Remaining failures

Locally the tests are still failing when changing the directory using the git_index. Expecting to cd to test_11 but the actual result directory is test_1.