### PR TITLE
plugin-ified scm_breeze

### DIFF
--- a/scm_breeze.plugin.zsh
+++ b/scm_breeze.plugin.zsh
@@ -1,0 +1,25 @@
+#########################################################
+# Forked from http://github.com/ndbroadbent/scm_breeze  #
+#                                                       #
+# File Copied and modified from ./install.sh            #
+# to be compatible with oh-my-zsh's plugin system       #
+#########################################################
+
+#!/bin/bash
+#locate the dir where this script is stored
+export scmbDir="$( cd -P "$( dirname "$0" )" && pwd )"
+
+# Symlink to ~/.scm_breeze if installing from another path
+if [ ! -s "$HOME/.scm_breeze" ] && [ "$scmbDir" != "$HOME/.scm_breeze" ]; then
+  ln -fs "$scmbDir" "$HOME/.scm_breeze"
+
+  # Load SCM Breeze update scripts
+  source "$scmbDir/lib/scm_breeze.sh"
+  # Create '~/.*.scmbrc' files from example files
+  _create_or_patch_scmbrc
+fi
+
+# This loads SCM Breeze into the shell session.
+[ -s "$HOME/.scm_breeze/scm_breeze.sh" ] && source "$HOME/.scm_breeze/scm_breeze.sh"
+
+


### PR DESCRIPTION
Modified install.sh to make it compatible with oh-my-zsh's plugin system.

I currently have this linked as a submodule in my custom plugins, but could just as easily be added to oh-my-zsh/plugins directly.

This way, there's no need to pollute your existing .zshrc file, as this will just load it along with everything else.