### PR TITLE
Use ^M instead of  for newlines

### DIFF
--- a/lib/git/keybindings.sh
+++ b/lib/git/keybindings.sh
@@ -27,13 +27,13 @@ if [[ "$git_keyboard_shortcuts_enabled" = "true" ]]; then
       # Uses emacs style keybindings, so vi mode is not supported for now
       if ! set -o | grep -q '^vi .*on$'; then
         if [[ $shell == "zsh" ]]; then
-          _bind "$git_commit_all_keys"              " git_commit_all""\n"
-          _bind "$git_add_and_commit_keys"          " \033[1~ git_add_and_commit ""\n"
-          _bind "$git_commit_all_with_ci_skip_keys" " \033[1~ APPEND='[ci skip]' git_commit_all ""\n"
+          _bind "$git_commit_all_keys"              " git_commit_all""^M"
+          _bind "$git_add_and_commit_keys"          " \033[1~ git_add_and_commit ""^M"
+          _bind "$git_commit_all_with_ci_skip_keys" " \033[1~ APPEND='[ci skip]' git_commit_all ""^M"
         else
-          _bind "$git_commit_all_keys"              "\" git_commit_all\n\""
-          _bind "$git_add_and_commit_keys"          "\"\C-A git_add_and_commit \n\""
-          _bind "$git_commit_all_with_ci_skip_keys" "\"\C-A APPEND='[ci skip]' git_commit_all \n\""
+          _bind "$git_commit_all_keys"              "\" git_commit_all^M\""
+          _bind "$git_add_and_commit_keys"          "\"\C-A git_add_and_commit ^M\""
+          _bind "$git_commit_all_with_ci_skip_keys" "\"\C-A APPEND='[ci skip]' git_commit_all ^M\""
         fi
       fi
 


### PR DESCRIPTION
Consider adding keybindings to make multiline editing easier such as the following:

```sh
if [[ "$MC_SID" != "" || "$MC_CONTROL_PID" != "" ]]; then
    bindkey "^J" accept-line
else
    bindkey "^J" self-insert
fi
```

When this is done `\n` no longer submits the command but `^M` will work in both cases.