### PR TITLE
Add alias & default shortcut for `git mergetool`

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -53,6 +53,7 @@ git_diff_file_alias="gdf"
 git_diff_word_alias="gdw"
 git_diff_cached_alias="gdc"
 git_difftool_alias="gdt"
+git_mergetool_alias="gmt"
 # 3. Standard commands
 git_clone_alias="gcl"
 git_fetch_alias="gf"

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -113,6 +113,7 @@ if [ "$git_setup_aliases" = "yes" ]; then
   __git_alias "$git_add_patch_alias"                'git' 'add' '-p'
   __git_alias "$git_add_updated_alias"              'git' 'add' '-u'
   __git_alias "$git_difftool_alias"                 'git' 'difftool'
+  __git_alias "$git_mergetool_alias"                'git' 'mergetool'
 
   # Custom default format for git log
   git_log_command="log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"


### PR DESCRIPTION
Provides parity with the `gdt` alias for `git difftool`