### PR TITLE
Add apkg repository update before install

### DIFF
--- a/test/support/travisci_deps.sh
+++ b/test/support/travisci_deps.sh
@@ -23,10 +23,10 @@ if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
   if [[ -z "$TEST_SHELLS" ]]; then needs_zsh=true; fi
 
   # finally, we install zsh if needed!
-  if $needs_zsh ; then
+  if $needs_zsh; then
+    sudo apt-get update
     sudo apt-get install zsh
   else
     echo "No deps required."
   fi
-
 fi


### PR DESCRIPTION
Travis CI env may have changed underneath us, so we need to update the apkg repositories before trying to install the `zsh` package.