### PR TITLE
Fix parsing of escaped shell command list

### DIFF
--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -23,7 +23,7 @@ if [ "$shell_command_wrapping_enabled" = "true" ] || [ "$bash_command_wrapping_e
     # Define 'whence' for bash, to get the value of an alias
     type whence > /dev/null 2>&1 || function whence() { LC_MESSAGES="C" type "$@" | sed -$SED_REGEX_ARG -e "s/.*is aliased to \`//" -e "s/'$//"; }
     local cmd=''
-    for cmd in $scmb_wrapped_shell_commands; do
+    for cmd in $(echo $scmb_wrapped_shell_commands); do
       if [ "${scmbDebug:-}" = "true" ]; then echo "SCMB: Wrapping $cmd..."; fi
 
       # Special check for 'cd', to make sure SCM Breeze is loaded after RVM


### PR DESCRIPTION
A change made in a6eeebf broke parsing of scmb_wrapped_shell_commands.
Rather than iterating over each command in the space-separated list, the
entire block of commands was treated as a single command.