### PR TITLE
Add shellcheck linting

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -170,8 +170,8 @@ if [ "$git_setup_aliases" = "yes" ]; then
   _alias "$git_log_graph_alias"           'git log --graph --max-count=5'
   _alias "$git_add_all_alias"             'git add --all .'
 
-  # Hub aliases (https://github.com/github/hub)
-  _alias "$git_pull_request_alias"        'git pull-request'
+  # GitHub CLI aliases (https://github.com/cli/cli)
+  _alias "$git_pull_request_alias"        'gh pr'
 fi
 
 


### PR DESCRIPTION
This simply adds the linting.

Relates to #287

It may be best to also add the exceptions (or adjustments) to make this pass testing as-is, since the repo is in a usable state as-is.