### PR TITLE
Fix infinite loop when parent directory does not exist

### DIFF
--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -118,6 +118,8 @@ git_status_shortcuts() {
 }
 # Template function for 'git_status_shortcuts'.
 _gs_output_file_group() {
+  local relative
+
   for i in ${stat_grp[$1]}; do
     # Print colored hashes & files based on modification groups
     local c_group="\033[0;$(eval echo -e \$c_grp_$1)"
@@ -126,8 +128,8 @@ _gs_output_file_group() {
     if [ -z "$project_root" ]; then
       relative="${stat_file[$i]}"
     else
-      absolute="$project_root/${stat_file[$i]}"
-      dest=$(readlink -f "$absolute")
+      local absolute="$project_root/${stat_file[$i]}"
+      local dest=$(readlink -f "$absolute")
       local pwd=$(readlink -f "$PWD")
       relative="$(_gs_relative_path "$pwd" "${dest:-$absolute}" )"
     fi

--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -126,9 +126,10 @@ _gs_output_file_group() {
     if [ -z "$project_root" ]; then
       relative="${stat_file[$i]}"
     else
-      dest=$(readlink -f "$project_root/${stat_file[$i]}")
+      absolute="$project_root/${stat_file[$i]}"
+      dest=$(readlink -f "$absolute")
       local pwd=$(readlink -f "$PWD")
-      relative="$(_gs_relative_path "$pwd" "$dest" )"
+      relative="$(_gs_relative_path "$pwd" "${dest:-$absolute}" )"
     fi
 
     if [[ $f -gt 10 && $e -lt 10 ]]; then local pad=" "; else local pad=""; fi   # (padding)
@@ -149,7 +150,7 @@ _gs_relative_path(){
   # Credit to 'pini' for the following script.
   # (http://stackoverflow.com/questions/2564634/bash-convert-absolute-path-into-relative-path-given-a-current-directory)
   target=$2; common_part=$1; back=""
-  while [[ "${target#$common_part}" == "${target}" ]]; do
+  while [[ -n "${common_part}" && "${target#$common_part}" == "${target}" ]]; do
     common_part="${common_part%/*}"
     back="../${back}"
   done


### PR DESCRIPTION
If the parent directory does not exist, `dest` is empty which puts `_gs_relative_path` into an infinite loop and the `gs` command hangs.

resolves #241 