### PR TITLE
README.md: add remark that some commands don't work w/o ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ to your `.bashrc` or `.zshrc`:
 
 `[ -s "$HOME/.scm_breeze/scm_breeze.sh" ] && source "$HOME/.scm_breeze/scm_breeze.sh"`
 
-**Note:** SCM Breeze performs much faster if you have ruby installed.
+**Note:** You need to install ruby for some SCM Breeze commands to work. This also improves performance. See [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/) for installation information.
 
 ### File Shortcuts
 


### PR DESCRIPTION
Add a remark that ruby is more than just recommended (quick fix for https://github.com/scmbreeze/scm_breeze/issues/279)

I've run into this situation multiple times with fresh systems, so this PR contains a quick fix/reminder for the time until the ruby dependency is refactored out (if that's still a plan for the future).