### PR TITLE
Fix shell wrapping for exes with space in path.

### DIFF
--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -82,7 +82,7 @@ if [ "$shell_command_wrapping_enabled" = "true" ] || [ "$bash_command_wrapping_e
         if [ "${scmbDebug:-}" = "true" ]; then echo "SCMB: $cmd is an executable file"; fi
         # Otherwise, command is a regular script or binary,
         # and the full path can be found with 'find_binary' function
-        alias $cmd="exec_scmb_expand_args $(find_binary $cmd)";;
+        alias $cmd="exec_scmb_expand_args '$(find_binary $cmd)'";;
       esac
     done
     # Clean up


### PR DESCRIPTION
I experienced this using VS Code in WSL, the `code` CLI is in the
Windows `PATH` that has a space in my user name.

Fixes #294.