### PR TITLE
Use ZDOTDIR env variable for path to .zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ features.
 ```bash
 git clone git://github.com/scmbreeze/scm_breeze.git ~/.scm_breeze
 ~/.scm_breeze/install.sh
-source ~/.bashrc   # or source ~/.zshrc
+source ~/.bashrc   # or source "${ZDOTDIR:-$HOME}/.zshrc"
 ```
 
 The install script creates required default configs and adds the following line
@@ -253,7 +253,7 @@ default base subdirectories are: Images, Backgrounds, Logos, Icons, Mockups,
 and Screenshots.
 
 After you have changed these settings, remember to run `source ~/.bashrc` or
-`source ~/.zshrc`.
+`source "${ZDOTDIR:-$HOME}/.zshrc"`.
 
 
 #### 2) Initialize design directories for your projects
@@ -324,7 +324,7 @@ Each feature is modular, so you are free to ignore the parts you don't want to
 use.  Just comment out the relevant line in `~/.scm_breeze/scm_breeze.sh`.
 
 **Note:** After changing any settings, you will need to run `source ~/.bashrc`
-(or `source ~/.zshrc`)
+(or `source "${ZDOTDIR:-$HOME}/.zshrc"`)
 
 I know we grow attached to the aliases we use every day, so I've made the alias
 system completely customizable.  You have two options when it comes to aliases:

--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,10 @@ fi
 # This loads SCM Breeze into the shell session.
 exec_string="[ -s \"$HOME/.scm_breeze/scm_breeze.sh\" ] && source \"$HOME/.scm_breeze/scm_breeze.sh\""
 
-# Add line to bashrc, zshrc, and bash_profile if not already present.
+# Add line to bashrc and bash_profile if not already present.
 added_to_profile=false
 already_present=false
-for rc in bashrc zshrc bash_profile; do
+for rc in bashrc bash_profile; do
   if [ -s "$HOME/.$rc" ]; then
     if grep -q "$exec_string" "$HOME/.$rc"; then
       printf "== Already installed in '~/.$rc'\n"
@@ -26,13 +26,27 @@ for rc in bashrc zshrc bash_profile; do
   fi
 done
 
+# Add line to .zshrc if not aleady present.
+# When set, the ZDOTDIR environment variable states the directory zshrc is in.
+# If not set, HOME environment variable is used as fallback.
+if [ -s "${ZDOTDIR:-$HOME}/.zshrc" ]; then
+  if grep -q "$exec_string" "${ZDOTDIR:-$HOME}/.zshrc"; then
+    printf "== Already installed in '${ZDOTDIR:-$HOME}/.zshrc'\n"
+    already_present=true  
+  else
+    printf "\n$exec_string\n" >> "${ZDOTDIR:-$HOME}/.zshrc"
+    printf "== Added SCM Breeze to '${ZDOTDIR:-$HOME}/.zshrc'\n"
+    already_present=true
+  fi
+fi
+
 # Load SCM Breeze update scripts
 source "$scmbDir/lib/scm_breeze.sh"
 # Create '~/.*.scmbrc' files from example files
 _create_or_patch_scmbrc
 
 if [ "$added_to_profile" = true ] || [ "$already_present" = true ]; then
-  echo "== SCM Breeze Installed! Run 'source ~/.bashrc || source ~/.bash_profile' or 'source ~/.zshrc'"
+  echo "== SCM Breeze Installed! Run 'source ~/.bashrc || source ~/.bash_profile' or 'source \"${ZDOTDIR:-$HOME}/.zshrc\"'"
   echo "   to load SCM Breeze into your current shell."
 else
   echo "== Error:"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,9 +7,12 @@ if [[ $OSTYPE == "Darwin" ]]; then
   sed="sed -i ''"
 fi
 
-for rc in bashrc zshrc; do
-  if [ -f "$HOME/.$rc" ]; then
-    $sed '/scm_breeze/d' "$HOME/.$rc" &&
-      printf "Removed SCM Breeze from %s\n" "$HOME/.$rc"
-  fi
-done
+if [ -f "$HOME/.bashrc" ]; then
+  $sed '/scm_breeze/d' "$HOME/.bashrc" &&
+  printf "Removed SCM Breeze from '%s'\n" "$HOME/.bashrc"
+fi
+
+if [ -f "${ZDOTDIR:-$HOME}/.zshrc" ]; then
+  $sed '/scm_breeze/d' "${ZDOTDIR:-$HOME}/.zshrc" &&
+  printf "Removed SCM Breeze from '%s'\n" "${ZDOTDIR:-$HOME}/.zshrc" 
+fi


### PR DESCRIPTION
Fixes #300.
`.zshrc` can be found at `~/.zshrc` when `ZDOTDIR` is not set.
If ZDOTDIR is set, .zshrc is in `${ZDOTDIR}/.zshrc`.
Using parameter expansion, the hardcoded path can be replaced with
`${ZDOTDIR:-$HOME}/.zshrc`. That way, it'll use the value in
`ZDOTDIR` when set and the value in `HOME` when not.
This thus mirrors the usage of `ZDOTDIR` in zsh and makes the code
more flexible.