### PR TITLE
Update command to identify `ls` command type

### DIFF
--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -97,7 +97,7 @@ fi
 if [ "$shell_ls_aliases_enabled" = "true" ] && builtin command -v ruby > /dev/null 2>&1; then
   # BSD ls is different to Linux (GNU) ls
   # Test for BSD ls
-  if ! ls --color=auto > /dev/null 2>&1; then
+  if ! ls --author > /dev/null 2>&1; then
     # ls is BSD
     _ls_bsd="BSD"
   fi


### PR DESCRIPTION
`ls --color=auto` runs successfully on recent versions of macOS (see https://github.com/fish-shell/fish-shell/issues/8309). So we need a different way to differentiate the two commands.

My main worry about this fix is that I don't know how widely available the `--author` flag is on Linux platforms. I tested it only on a recent version of Ubuntu.

Fixes #312.
