### PR TITLE
Switch to output parse of `--version` to determine ls version

### DIFF
--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -97,7 +97,7 @@ fi
 if [ "$shell_ls_aliases_enabled" = "true" ] && builtin command -v ruby > /dev/null 2>&1; then
   # BSD ls is different to Linux (GNU) ls
   # Test for BSD ls
-  if ! ls --color=auto > /dev/null 2>&1; then
+  if ! (ls --version 2>/dev/null || echo "BSD") | grep GNU >/dev/null 2>&1; then
     # ls is BSD
     _ls_bsd="BSD"
   fi


### PR DESCRIPTION
Alternative to #317 to fix #312.

I don't have a mac to test this on, if someone with a mac could test and confirm this is working as expected that would be excellent.

@patbl

```shell
$ if ! ls --version | grep GNU >/dev/null 2>&1; then echo "BSD"; else echo "GNU"; fi
GNU
Thu Jun 23 08:29:15 AM EDT 2022
0 ghthor@hivemind ~/.scm_breeze [test-bsd-ls]
```