### PR TITLE
Use File.exist over deprecated File.exists

### DIFF
--- a/lib/git/status_shortcuts.rb
+++ b/lib/git/status_shortcuts.rb
@@ -88,7 +88,7 @@ puts "%s#%s On branch: %s#{@branch}#{difference}%s  %s|  [%s*%s]%s => $#{ENV["gi
 ]
 
 def has_modules?
-  @has_modules ||= File.exists?(File.join(@project_root, '.gitmodules'))
+  @has_modules ||= File.exist?(File.join(@project_root, '.gitmodules'))
 end
 
 # Index modification states


### PR DESCRIPTION
Fixes #322. The issue says it's deprecated in 3.2.0, however `.exists` has been deprecated for ages and was removed in 3.2.0. `scm_breeze` completely broke for me when upgrading ruby.

I was able to confirm this fixing the issue on my Mac 12.6, ruby 3.2.0.