### PR TITLE
git:branch legacy return no error code when git branch succeeds.

### DIFF
--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -17,7 +17,7 @@ function _scmb_git_branch_shortcuts {
   # Fall back to normal git branch, if any unknown args given
   if [[ "$($_git_cmd branch | wc -l)" -gt 300 ]] || ([[ -n "$@" ]] && [[ "$@" != "-a" ]]); then
     exec_scmb_expand_args $_git_cmd branch "$@"
-    return 1
+    return $?
   fi
 
   # Use ruby to inject numbers into git branch output


### PR DESCRIPTION
### What
Return error code `0` if successfully call `git branch` instead of always returning `1`.

### Why
I have some commands that do things like `git branch -d blah && do-another-thing` and since I installed scm_breeze they broke. It appears scm_breeze was _always_ returning error code of 1 which broke things.