### PR TITLE
fix rc file suffix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ doesn't need to 'learn' anything, and it can do SCM-specific stuff like:
 
 The default alias for `git_index` is 'c', which might stand for 'code'
 
-You will first need to configure your repository directory by setting `GIT_REPO_DIR` in `~/.git.sbmrc`.
+You will first need to configure your repository directory by setting `GIT_REPO_DIR` in `~/.git.scmbrc`.
 
 Then, build the index:
 


### PR DESCRIPTION
The readme had the wrong suffix - setting GIT_REPO_DIR in `~/.git.scmrc` does not work, but setting it in `~/.git.scmbrc` does