### PR TITLE
[example] switch to declaring wrapped commands as an array

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -126,6 +126,6 @@ git_add_and_amend_commit_keys="\C-xz"     # CTRL+x, z
 # Expand numbered args for common shell commands
 shell_command_wrapping_enabled="true"
 # Here you can tweak the list of wrapped commands.
-scmb_wrapped_shell_commands="vim emacs gedit cat rm cp mv ln cd ls less subl code"
+scmb_wrapped_shell_commands=(vim emacs gedit cat rm cp mv ln cd ls less subl code)
 # Add numbered shortcuts to output of ls -l, just like 'git status'
 shell_ls_aliases_enabled="true"


### PR DESCRIPTION
I've tested declaring the wrapped commands as an array in both zsh and bash and
both are working for me.

1. Closes #297
1. Closes #283
1. Closes #284
