### PR TITLE
feat: make the design/asset feature optional

### DIFF
--- a/scm_breeze.sh
+++ b/scm_breeze.sh
@@ -9,8 +9,13 @@ export scmbDir="$(dirname ${BASH_SOURCE:-$0})"
 
 # Shared functions
 source "$scmbDir/lib/scm_breeze.sh"
-# Design assets management
-source "$scmbDir/lib/design.sh"
+
+SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT=${SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT:-""}
+
+if [ "$SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT" != "true" ]; then
+  echo "scm_breeze: Design Assets management enabled"
+  source "$scmbDir/lib/design.sh"
+fi
 
 # Git
 # ------------------------------------------------------------
@@ -24,13 +29,14 @@ if [[ -s "$HOME/.git.scmbrc" ]]; then
   source "$scmbDir/lib/git/branch_shortcuts.sh"
   source "$scmbDir/lib/git/grep_shortcuts.sh"
   source "$scmbDir/lib/git/shell_shortcuts.sh"
-  source "$scmbDir/lib/git/repo_index.sh"
+  if [ "$SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT" != "true" ]; then
+    source "$scmbDir/lib/git/repo_index.sh"
+  fi
   source "$scmbDir/lib/git/tools.sh"
 
-  if ! type ruby > /dev/null 2>&1; then
+  if ! type ruby >/dev/null 2>&1; then
     # If Ruby is not installed, fall back to the
     # slower bash/zsh implementation of 'git_status_shortcuts'
     source "$scmbDir/lib/git/fallback/status_shortcuts_shell.sh"
   fi
 fi
-

--- a/scmbrc.example
+++ b/scmbrc.example
@@ -11,3 +11,7 @@ export design_av_dirs="Animations Videos Flash Music Samples"
 # Directories for global design assets (not symlinked into projects)
 export design_ext_dirs="Fonts IconSets"
 
+# Set =true to disable the design/assets management features
+# export SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT=true
+
+# vi: ft=sh


### PR DESCRIPTION
`SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT=true` will
disable the asset management portion of the shell integration.

I don't use it, I've never used it. I know I discussed with @vise890 years ago about how to remove it so we could have a lean core for the shell & git shortcuts part of this package.

It's still on by default, but adding the environment variable will disable it, so I'm going to merge this with the longterm intention of completely splitting these 2 systems apart.
