### PR TITLE
fix: replace global `shell` variable with JIT shell detection

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -76,7 +76,7 @@ __git_alias () {
 
     alias $alias_str="$cmd_prefix $cmd${cmd_args:+ }${cmd_args[*]}"
     if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
-      if [ "$shell" = "bash" ]; then
+      if breeze_shell_is "bash"; then
         __define_git_completion "$alias_str" "$cmd"
         complete -o default -o nospace -F _git_"$alias_str"_shortcut "$alias_str"
       fi
@@ -179,11 +179,10 @@ if [ "$GIT_SETUP_ALIASES" = "yes" ]; then
   _alias "$git_pull_request_alias"        'gh pr'
 fi
 
-
-
+# TODO(ghthor): apply these same fixes for NixOS
 # Tab completion
 if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
-  if [ $shell = "bash" ]; then
+  if breeze_shell_is "bash"; then
     # Fix to preload Arch bash completion for git
     [[ -s "/usr/share/git/completion/git-completion.bash" ]] && source "/usr/share/git/completion/git-completion.bash"
     # new path in Ubuntu 13.04

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -21,7 +21,8 @@ function _scmb_git_branch_shortcuts {
   fi
 
   # Use ruby to inject numbers into git branch output
-  ruby -e "$( cat <<EOF
+  ruby -e "$(
+    cat <<EOF
     output = %x($_git_cmd branch --color=always $(token_quote "$@"))
     line_count = output.lines.to_a.size
     output.lines.each_with_index do |line, i|
@@ -29,7 +30,7 @@ function _scmb_git_branch_shortcuts {
       puts line.sub(/^([ *]{2})/, "\\\1\033[2;37m[\033[0m#{i+1}\033[2;37m]\033[0m" << spaces)
     end
 EOF
-)"
+  )"
 
   # Set numbered file shortcut in variable
   local e=1 IFS=$'\n'
@@ -48,7 +49,7 @@ __git_alias "$git_branch_delete_force_alias" "_scmb_git_branch_shortcuts" "-D"
 
 # Define completions for git branch shortcuts
 if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
-  if [ "$shell" = "bash" ]; then
+  if breeze_shell_is "bash"; then
     for alias_str in $git_branch_alias $git_branch_all_alias $git_branch_move_alias $git_branch_delete_alias; do
       __define_git_completion $alias_str branch
       complete -o default -o nospace -F _git_"$alias_str"_shortcut $alias_str

--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -53,10 +53,14 @@ git_status_shortcuts() {
     echo -e "$c_dark#$c_rst On branch: $c_branch$branch$c_rst  $c_dark|  [$c_rst*$c_dark]$c_rst => \$$GIT_ENV_CHAR*\n$c_dark#$c_rst"
 
     for line in $git_status; do
-      if [[ $shell == *bash ]]; then
-        x=${line:0:1}; y=${line:1:1}; file=${line:3}
+      if breeze_shell_is "bash"; then
+        x=${line:0:1}
+        y=${line:1:1}
+        file=${line:3}
       else
-        x=$line[1]; y=$line[2]; file=$line[4,-1]
+        x=$line[1]
+        y=$line[2]
+        file=$line[4,-1]
       fi
 
       # Index modification states

--- a/lib/git/keybindings.sh
+++ b/lib/git/keybindings.sh
@@ -10,9 +10,9 @@
 # See [here](http://qntm.org/bash#sec1) for info about why I wanted a prompt.
 
 # Cross-shell key bindings
-_bind(){
+_bind() {
   if [ -n "$1" ]; then
-    if [[ $shell == "zsh" ]]; then
+    if breeze_shell_is "zsh"; then
       bindkey -s "$1" "$2"
     else # bash
       bind "\"$1\": $2"
@@ -24,11 +24,11 @@ _bind(){
 if [[ "$git_keyboard_shortcuts_enabled" = "true" ]]; then
   case "$-" in
   *i*)
-      if [ -n "$ZSH_VERSION" ]; then
-        RETURN_CHAR="^M"
-      else
-        RETURN_CHAR="\n"
-      fi
+    if [ -n "$ZSH_VERSION" ]; then
+      RETURN_CHAR="^M"
+    else
+      RETURN_CHAR="\n"
+    fi
 
       # Uses emacs style keybindings, so vi mode is not supported for now
       if ! set -o | grep -q '^vi .*on$'; then

--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -79,8 +79,8 @@ function git_index() {
       echo
 
     # If $1 starts with '/', change to top-level directory within $GIT_REPO_DIR
-    elif ([ $shell = "bash" ] && [ "${1:0:1}" = "/" ]) || \
-         ([ $shell = "zsh" ]  && [ "${1[1]}"  = "/" ]); then
+    elif (breeze_shell_is "bash" && [ "${1:0:1}" = "/" ]) || \
+         (breeze_shell_is "zsh"  && [ "${1[1]}"  = "/" ]); then
       if [ -d "$GIT_REPO_DIR$1" ]; then
         builtin cd "$GIT_REPO_DIR$1"
       fi
@@ -278,7 +278,7 @@ function _git_index_batch_cmd() {
 }
 
 
-if [ $shell = 'bash' ]; then
+if breeze_shell_is "bash"; then
 	# Bash tab completion function for git_index()
 	function _git_index_tab_completion() {
 		_check_git_index

--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -127,7 +127,7 @@ if [ "$shell_ls_aliases_enabled" = "true" ] && builtin command -v ruby >/dev/nul
       ll_output="$(CLICOLOR_FORCE=1 "${ll_command[@]}" -lG "$@")"
     fi
 
-    if [[ $shell == "zsh" ]]; then
+    if breeze_shell_is "zsh"; then
       # Ensure sh_word_split is on
       [[ -o shwordsplit ]] && SHWORDSPLIT_ON=true
       setopt shwordsplit
@@ -227,7 +227,7 @@ EOF
     done
 
     # Turn off shwordsplit unless it was on previously
-    if [[ $shell == "zsh" && -z $SHWORDSPLIT_ON ]]; then unsetopt shwordsplit; fi
+    if breeze_shell_is "zsh" && [[ -z $SHWORDSPLIT_ON ]]; then unsetopt shwordsplit; fi
   }
 
   # Setup aliases

--- a/lib/git/tools.sh
+++ b/lib/git/tools.sh
@@ -19,22 +19,21 @@
 git_remove_history() {
   # Make sure we're at the root of a git repo
   if [ ! -d .git ]; then
-      echo "Error: must run this script from the root of a git repository"
-      return
+    echo "Error: must run this script from the root of a git repository"
+    return
   fi
   # Remove all paths passed as arguments from the history of the repo
   local files
   files=("$@")
   $_git_cmd filter-branch --index-filter "$_git_cmd rm -rf --cached --ignore-unmatch ${files[*]}" HEAD
   # Remove the temporary history git-filter-branch otherwise leaves behind for a long time
-  rm -rf .git/refs/original/ && $_git_cmd reflog expire --all &&  $_git_cmd gc --aggressive --prune
+  rm -rf .git/refs/original/ && $_git_cmd reflog expire --all && $_git_cmd gc --aggressive --prune
 }
-
 
 # Set default remote and merge for a git branch (pull and push)
 # Usage: git_set_default_remote(branch = master, remote = origin)
 git_set_default_remote() {
-  curr_branch=$($_git_cmd branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/')
+  curr_branch=$($_git_cmd branch 2>/dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/')
   if [ -n "$1" ]; then branch="$1"; else branch="$curr_branch"; fi
   if [ -n "$2" ]; then remote="$2"; else remote="origin"; fi
   echo "branch.$branch.remote: $remote"
@@ -47,7 +46,7 @@ git_set_default_remote() {
 # Usage: git_ignore [rule] [ignore_file=.gitignore]
 __git_ignore() {
   if [ -n "$2" ]; then local f="$2"; else local f=".gitignore"; fi
-  if [ -n "$1" ] && ! ([ -e $f ] && grep -q "$1" $f); then echo "$1" >> $f; fi
+  if [ -n "$1" ] && ! ([ -e $f ] && grep -q "$1" $f); then echo "$1" >>$f; fi
 }
 # Always expand args
 git_ignore() {
@@ -81,7 +80,7 @@ git_exclude_basename() {
 #
 git_bisect_grep() {
   if [ -z "$2" ]; then
-    echo "Usage: $0 <good_revision> <string>";
+    echo "Usage: $0 <good_revision> <string>"
     return
   fi
   if [ -n "$3" ]; then search_path="$3"; else search_path="."; fi
@@ -123,7 +122,7 @@ git_swap_remotes() {
 }
 # (use git fetch tab completion)
 if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
-  if [ "$shell" = "bash" ]; then
+  if breeze_shell_is "bash"; then
     complete -o default -o nospace -F _git_fetch git_swap_remotes
   fi
 fi

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -1,13 +1,48 @@
 # Detect shell
-if [ -n "${ZSH_VERSION:-}" ]; then shell="zsh"; else shell="bash"; fi
+breeze_detect_shell() {
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    echo "zsh"
+  else
+    echo "bash"
+  fi
+}
+
+breeze_shell_is() {
+  [ "$(breeze_detect_shell)" = "$1" ] && return 0
+  return 1
+}
 # Detect whether zsh 'shwordsplit' option is on by default.
-if [ $shell = "zsh" ]; then zsh_shwordsplit=$( (setopt | grep -q shwordsplit) && echo "true" ); fi
+if breeze_shell_is "zsh"; then
+  zsh_shwordsplit=$( (setopt | grep -q shwordsplit) && echo "true")
+fi
+
 # Switch on/off shwordsplit for functions that require it.
-zsh_compat(){ if [ $shell = "zsh" ] && [ -z $zsh_shwordsplit ]; then setopt shwordsplit; fi; }
-zsh_reset(){  if [ $shell = "zsh" ] && [ -z $zsh_shwordsplit ]; then unsetopt shwordsplit; fi; }
+zsh_compat() {
+  if breeze_shell_is "zsh" && [ -z $zsh_shwordsplit ]; then
+    setopt shwordsplit
+  fi
+}
+zsh_reset() {
+  if breeze_shell_is "zsh" && [ -z $zsh_shwordsplit ]; then
+    unsetopt shwordsplit
+  fi
+}
+
 # Enable/disable nullglob for zsh or bash
-enable_nullglob()  { if [ $shell = "zsh" ]; then setopt NULL_GLOB;   else shopt -s nullglob; fi; }
-disable_nullglob() { if [ $shell = "zsh" ]; then unsetopt NULL_GLOB; else shopt -u nullglob; fi; }
+enable_nullglob() {
+  if breeze_shell_is "zsh"; then
+    setopt NULL_GLOB
+  else
+    shopt -s nullglob
+  fi
+}
+disable_nullglob() {
+  if breeze_shell_is "zsh"; then
+    unsetopt NULL_GLOB
+  else
+    shopt -u nullglob
+  fi
+}
 
 # Alias wrapper that ignores errors if alias is not defined.
 _safe_alias(){ alias "$@" 2> /dev/null; }
@@ -31,7 +66,7 @@ function token_quote {
   # Keep this code for use when minimum versions of {ba,z}sh can be increased.
   # See https://github.com/scmbreeze/scm_breeze/issues/260
   #
-  # if [[ $shell = bash ]]; then
+  # if breeze_detect_shell "bash"; then
   #   # ${parameter@operator} where parameter is ${@} and operator is 'Q'
   #   # https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
   #   eval "${@@Q}"
@@ -50,7 +85,7 @@ function _safe_eval() {
   # Keep this code for use when minimum versions of {ba,z}sh can be increased.
   # See https://github.com/scmbreeze/scm_breeze/issues/260
   #
-  # if [[ $shell = bash ]]; then
+  # if breeze_detect_shell "bash"; then
   #   # ${parameter@operator} where parameter is ${@} and operator is 'Q'
   #   # https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
   #   eval "${@@Q}"
@@ -60,8 +95,8 @@ function _safe_eval() {
   # fi
 }
 
-find_binary(){
-  if [ $shell = "zsh" ]; then
+find_binary() {
+  if breeze_shell_is "bash"; then
     builtin type -p "$1" | sed "s/$1 is //" | head -1
   else
     builtin type -P "$1"

--- a/test/lib/git/status_shortcuts_test.sh
+++ b/test/lib/git/status_shortcuts_test.sh
@@ -335,7 +335,7 @@ test_git_commit_prompt() {
   assertIncludes "$git_show_output" "$commit_msg"
 
   # Test that history was appended correctly.
-  if [[ $shell == "zsh" ]]; then
+  if breeze_shell_is "zsh"; then
     test_history="$(history)"
     # TODO(ghthor): zsh isn't working here
     # assertIncludes "$test_history" "git commit -m \"$dbl_escaped_msg\""
@@ -371,7 +371,7 @@ test_git_commit_prompt_with_append() {
   assertIncludes "$git_show_output" "$commit_msg \[ci skip\]"
 
   # Test that history was appended correctly.
-  if [[ $shell == "zsh" ]]; then
+  if breeze_shell_is "zsh"; then
     test_history="$(history)"
     # TODO(ghthor): zsh isn't working here
     # assertIncludes "$test_history" "$commit_msg \[ci skip\]"


### PR DESCRIPTION
This fixes conflicts where when direnv/nix develop activates it would unset this global `shell` variable.
