### PR TITLE
fix: Remove nag message for assets management

### DIFF
--- a/scm_breeze.sh
+++ b/scm_breeze.sh
@@ -13,7 +13,6 @@ source "$scmbDir/lib/scm_breeze.sh"
 SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT=${SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT:-""}
 
 if [ "$SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT" != "true" ]; then
-  echo "scm_breeze: Design Assets management enabled"
   source "$scmbDir/lib/design.sh"
 fi
 


### PR DESCRIPTION
Anyone who didn't opt out of the assets management feature (by setting SCM_BREEZE_DISABLE_ASSETS_MANAGEMENT) would be shown a nag message every time they started a shell, which adds unnecessary noise.