### PR TITLE
mcrockett/Add option to turn off setup of shell completion

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -14,6 +14,8 @@ export ga_auto_remove="yes"
 #   Note: Bash tab completion will not be automatically set up for your aliases if you disable this option.
 export git_setup_aliases="yes"
 
+# - Set the following option to 'yes' if you want to turn off shell completion setup
+# export git_skip_shell_completion="yes" 
 
 # Git Index Config
 # ----------------------------------------------

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -47,9 +47,11 @@ __git_alias "$git_branch_delete_alias"       "_scmb_git_branch_shortcuts" "-d"
 __git_alias "$git_branch_delete_force_alias" "_scmb_git_branch_shortcuts" "-D"
 
 # Define completions for git branch shortcuts
-if [ "$shell" = "bash" ]; then
-  for alias_str in $git_branch_alias $git_branch_all_alias $git_branch_move_alias $git_branch_delete_alias; do
-    __define_git_completion $alias_str branch
-    complete -o default -o nospace -F _git_"$alias_str"_shortcut $alias_str
-  done
+if [ "$git_skip_shell_completion" != "yes" ]; then
+  if [ "$shell" = "bash" ]; then
+    for alias_str in $git_branch_alias $git_branch_all_alias $git_branch_move_alias $git_branch_delete_alias; do
+      __define_git_completion $alias_str branch
+      complete -o default -o nospace -F _git_"$alias_str"_shortcut $alias_str
+    done
+  fi
 fi

--- a/lib/git/tools.sh
+++ b/lib/git/tools.sh
@@ -122,8 +122,10 @@ git_swap_remotes() {
   echo "Swapped $1 <-> $2"
 }
 # (use git fetch tab completion)
-if [ "$shell" = "bash" ]; then
-  complete -o default -o nospace -F _git_fetch git_swap_remotes
+if [ "$git_skip_shell_completion" != "yes" ]; then
+  if [ "$shell" = "bash" ]; then
+    complete -o default -o nospace -F _git_fetch git_swap_remotes
+  fi
 fi
 
 


### PR DESCRIPTION
### Issue
- When I moved from Linux => Mac I didn't have bash completion package installed and so got these errors (plus turns out I really prefer to complete on filenames even though the branch complete is a nice feature)

Screenshot of errors I see:
![Screenshot 2024-12-11 at 1 32 14 PM](https://github.com/user-attachments/assets/56e4d8b4-cb00-481e-9e4b-2c1723a4f45f)

### Proposed Fix
- Add an option `git_skip_shell_completion` that is backward compatible and will ignore any shell completion setup