### PR TITLE
Use uppercase names for exported variables to avoid shellcheck warnings (SC2154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,8 @@ you can type `gco <tab>` to tab complete your list of branches.
 
 ### 2) Use your own aliases
 
-In your `git.scmbrc` config file, just set the `git_setup_aliases` option to
-`no`. Your existing git aliases will then be used, and you will still be able
+In your `git.scmbrc` config file, just set `GIT_SETUP_ALIASES` to `no`.
+Your existing git aliases will then be used, and you will still be able
 to use the numeric shortcuts feature. SCM Breeze creates a function to wrap
 the 'git' command, which expands numeric arguments, and uses `hub` if
 available.

--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -3,19 +3,19 @@
 # ----------------------------------------------
 # - Set your preferred prefix for env variable file shortcuts.
 #   (I chose 'e' because it is easy to slide your finger to it from '$'.)
-export git_env_char="e"
+export GIT_ENV_CHAR="e"
 # - Max changed files before reverting to 'git status'. git_status_shortcuts() will be slower for lots of changed files.
-export gs_max_changes="150"
-# - When using the git_add_shorcuts() command, automatically invoke 'git rm' to remove deleted files?
-export ga_auto_remove="yes"
+export GS_MAX_CHANGES="150"
+# - When using the git_add_shortcuts() command, automatically invoke 'git rm' to remove deleted files?
+export GA_AUTO_REMOVE="yes"
 
 # - Set the following option to 'no' if you want to use your existing git aliases
 #   instead of overwriting them.
 #   Note: Bash tab completion will not be automatically set up for your aliases if you disable this option.
-export git_setup_aliases="yes"
+export GIT_SETUP_ALIASES="yes"
 
 # - Set the following option to 'yes' if you want to turn off shell completion setup
-# export git_skip_shell_completion="yes" 
+# export GIT_SKIP_SHELL_COMPLETION="yes"
 
 # Git Index Config
 # ----------------------------------------------
@@ -24,7 +24,7 @@ export GIT_REPO_DIR="$HOME/code"
 # Add the full paths of any extra repos to GIT_REPOS, separated with ':'
 # e.g. "/opt/rails/project:/opt/rails/another project:$HOME/other/repo"
 export GIT_REPOS=""
-export git_status_command="git_status_shortcuts"
+export GIT_STATUS_COMMAND="git_status_shortcuts"
 # Alias
 git_index_alias="c"    # Switch to a repo in the (c)ode directory
 

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -75,7 +75,7 @@ __git_alias () {
     fi
 
     alias $alias_str="$cmd_prefix $cmd${cmd_args:+ }${cmd_args[*]}"
-    if [ "$git_skip_shell_completion" != "yes" ]; then
+    if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
       if [ "$shell" = "bash" ]; then
         __define_git_completion "$alias_str" "$cmd"
         complete -o default -o nospace -F _git_"$alias_str"_shortcut "$alias_str"
@@ -96,8 +96,8 @@ _alias "$git_grep_shortcuts_alias"    'git_grep_shortcuts'
 # Git Index alias
 _alias "$git_index_alias"             'git_index'
 
-# Only set up the following aliases if 'git_setup_aliases' is 'yes'
-if [ "$git_setup_aliases" = "yes" ]; then
+# Only set up the following aliases if GIT_SETUP_ALIASES is 'yes'
+if [ "$GIT_SETUP_ALIASES" = "yes" ]; then
 
   # Commands that deal with paths
   __git_alias "$git_checkout_alias"                 'git' 'checkout'
@@ -182,7 +182,7 @@ fi
 
 
 # Tab completion
-if [ "$git_skip_shell_completion" != "yes" ]; then
+if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
   if [ $shell = "bash" ]; then
     # Fix to preload Arch bash completion for git
     [[ -s "/usr/share/git/completion/git-completion.bash" ]] && source "/usr/share/git/completion/git-completion.bash"

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -34,8 +34,8 @@ EOF
   # Set numbered file shortcut in variable
   local e=1 IFS=$'\n'
   for branch in $($_git_cmd branch "$@" | sed "s/^[* ]\{2\}//"); do
-    export $git_env_char$e="$branch"
-    if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$git_env_char$e  => $file"; fi
+    export $GIT_ENV_CHAR$e="$branch"
+    if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$GIT_ENV_CHAR$e  => $file"; fi
     let e++
   done
 }
@@ -47,7 +47,7 @@ __git_alias "$git_branch_delete_alias"       "_scmb_git_branch_shortcuts" "-d"
 __git_alias "$git_branch_delete_force_alias" "_scmb_git_branch_shortcuts" "-D"
 
 # Define completions for git branch shortcuts
-if [ "$git_skip_shell_completion" != "yes" ]; then
+if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
   if [ "$shell" = "bash" ]; then
     for alias_str in $git_branch_alias $git_branch_all_alias $git_branch_move_alias $git_branch_delete_alias; do
       __define_git_completion $alias_str branch

--- a/lib/git/compatibility.sh
+++ b/lib/git/compatibility.sh
@@ -1,0 +1,21 @@
+# Earlier versions of SCM Breeze used lowercase variables.
+# We now use uppercase variables for exported variables to follow conventions
+# and prevent shellcheck warnings. See: https://www.shellcheck.net/wiki/SC2154
+# This file converts the old lowercase variables to uppercase if they are not already set.
+
+for setting_var in \
+  GIT_ENV_CHAR \
+  GS_MAX_CHANGES \
+  GA_AUTO_REMOVE \
+  GIT_SETUP_ALIASES \
+  GIT_SKIP_SHELL_COMPLETION \
+  GIT_REPO_DIR \
+  GIT_STATUS_COMMAND
+do
+  lower=$(echo "$setting_var" | tr '[:upper:]' '[:lower:]')
+  eval "upper_var=\${$setting_var:-}"
+  eval "lower_var=\${$lower:-}"
+  if [ -z "$upper_var" ] && [ -n "$lower_var" ]; then
+    eval "export $setting_var=\$lower_var"
+  fi
+done

--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -20,10 +20,10 @@ git_status_shortcuts() {
   local git_status="$(git status --porcelain 2> /dev/null)"
   local i
 
-  if [ -n "$git_status" ] && [[ $(echo "$git_status" | wc -l) -le $gs_max_changes ]]; then
+  if [ -n "$git_status" ] && [[ $(echo "$git_status" | wc -l) -le $GS_MAX_CHANGES ]]; then
     unset stat_file; unset stat_col; unset stat_msg; unset stat_grp; unset stat_x; unset stat_y
     # Clear numbered env variables.
-    for (( i=1; i<=$gs_max_changes; i++ )); do unset $git_env_char$i; done
+    for (( i=1; i<=$GS_MAX_CHANGES; i++ )); do unset $GIT_ENV_CHAR$i; done
 
     # Get branch
     local branch=`git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/'`
@@ -50,7 +50,7 @@ git_status_shortcuts() {
 
     local f=1; local e=1  # Counters for number of files, and ENV variables
 
-    echo -e "$c_dark#$c_rst On branch: $c_branch$branch$c_rst  $c_dark|  [$c_rst*$c_dark]$c_rst => \$$git_env_char*\n$c_dark#$c_rst"
+    echo -e "$c_dark#$c_rst On branch: $c_branch$branch$c_rst  $c_dark|  [$c_rst*$c_dark]$c_rst => \$$GIT_ENV_CHAR*\n$c_dark#$c_rst"
 
     for line in $git_status; do
       if [[ $shell == *bash ]]; then
@@ -141,7 +141,7 @@ $pad$c_dark [$c_rst$e$c_dark] $c_group$relative$c_rst"
     # (Exports full path, but displays relative path)
     # fetch first file (in the case of oldFile -> newFile) and remove quotes
     local filename=$(eval echo $(echo ${stat_file[$i]} | grep -E -o '^"([^\\"]*(\\.[^"]*)*)"|^[^ ]+'))
-    export $git_env_char$e="$project_root/$filename"
+    export $GIT_ENV_CHAR$e="$project_root/$filename"
     let e++
   done
   echo -e "$c_hash#$c_rst"

--- a/lib/git/grep_shortcuts.sh
+++ b/lib/git/grep_shortcuts.sh
@@ -13,7 +13,7 @@ git_grep_shortcuts() {
   IFS="|"
   local e=1
   for file in ${=files}; do
-    export $git_env_char$e="$file"
+    export $GIT_ENV_CHAR$e="$file"
     let e++
   done
   IFS=$' \t\n'

--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -178,8 +178,8 @@ function parse_git_branch {
 function _git_index_status_if_dirty() {
   if ! [ `git status --porcelain | wc -l` -eq 0 ]; then
     # Fall back to 'git status' if git status alias isn't configured
-    if type $git_status_command 2>&1 | \grep -qv "not found"; then
-      eval $git_status_command
+    if type $GIT_STATUS_COMMAND 2>&1 | \grep -qv "not found"; then
+      eval $GIT_STATUS_COMMAND
     else
       git status
     fi

--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -221,8 +221,8 @@ EOF
     local IFS=$'\n'
     for file in $ll_files; do
       file=$rel_path/$file
-      export $git_env_char$e=$("${_abs_path_command[@]}" "$file")
-      if [[ ${scmbDebug:-} = true ]]; then echo "Set \$$git_env_char$e  => $file"; fi
+      export $GIT_ENV_CHAR$e=$("${_abs_path_command[@]}" "$file")
+      if [[ ${scmbDebug:-} = true ]]; then echo "Set \$$GIT_ENV_CHAR$e  => $file"; fi
       let e++
     done
 

--- a/lib/git/status_shortcuts.rb
+++ b/lib/git/status_shortcuts.rb
@@ -32,7 +32,7 @@ git_branch = git_status_lines[0]
 
 @changes = git_status_lines[1..-1]
 # Exit if too many changes
-exit if @changes.size > ENV["gs_max_changes"].to_i
+exit if @changes.size > ENV["GS_MAX_CHANGES"].to_i
 
 # Colors
 @c = {
@@ -83,7 +83,7 @@ if @changes.size == 0
   exit
 end
 
-puts "%s#%s On branch: %s#{@branch}#{difference}%s  %s|  [%s*%s]%s => $#{ENV["git_env_char"]}*\n%s#%s" % [
+puts "%s#%s On branch: %s#{@branch}#{difference}%s  %s|  [%s*%s]%s => $#{ENV["GIT_ENV_CHAR"]}*\n%s#%s" % [
   @c[:dark], @c[:rst], @c[:branch], @c[:rst], @c[:dark], @c[:rst], @c[:dark], @c[:rst], @c[:dark], @c[:rst]
 ]
 

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -29,7 +29,7 @@ git_status_shortcuts() {
   if [[ -z "$cmd_output" ]]; then
     # Just show regular git status if ruby script returns nothing.
     git status
-    echo -e "\n\033[33mThere were more than $gs_max_changes changed files. SCM Breeze has fallen back to standard \`git status\` for performance reasons.\033[0m"
+    echo -e "\n\033[33mThere were more than $GS_MAX_CHANGES changed files. SCM Breeze has fallen back to standard \`git status\` for performance reasons.\033[0m"
     return 1
   fi
   # Fetch list of files from last line of script output
@@ -39,8 +39,8 @@ git_status_shortcuts() {
   local IFS="|"
   local e=1
   for file in $files; do
-    export $git_env_char$e="$file"
-    if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$git_env_char$e  => $file"; fi
+    export $GIT_ENV_CHAR$e="$file"
+    if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$GIT_ENV_CHAR$e  => $file"; fi
     let e++
   done
 
@@ -65,7 +65,7 @@ git_add_shortcuts() {
     echo "       ga 1       => git add \$e1"
     echo "       ga 2-4    => git add \$e2 \$e3 \$e4"
     echo "       ga 2 5-7  => git add \$e2 \$e5 \$e6 \$e7"
-    if [[ $ga_auto_remove == "yes" ]]; then
+    if [[ $GA_AUTO_REMOVE == "yes" ]]; then
       echo -e "\nNote: Deleted files will also be staged using this shortcut."
       echo "      To turn off this behaviour, change the 'auto_remove' option."
     fi
@@ -82,8 +82,8 @@ git_silent_add_shortcuts() {
     local args
     eval args="$(scmb_expand_args "$@")"  # populate $args array
     for file in "${args[@]}"; do
-      # Use 'git rm' if file doesn't exist and 'ga_auto_remove' is enabled.
-      if [[ $ga_auto_remove = yes && ! -e $file ]]; then
+      # Use 'git rm' if file doesn't exist and GA_AUTO_REMOVE is enabled.
+      if [[ $GA_AUTO_REMOVE = yes && ! -e $file ]]; then
         echo -n "# "
         git rm "$file"
       else
@@ -104,7 +104,7 @@ git_show_affected_files(){
   echo -n "# "; git show --oneline --name-only "$@" | head -n1; echo "# "
   for file in $(git show --pretty="format:" --name-only "$@" | \grep -v '^$'); do
     let f++
-    export $git_env_char$f=$file     # Export numbered variable.
+    export $GIT_ENV_CHAR$f=$file     # Export numbered variable.
     echo -e "#     \033[2;37m[\033[0m$f\033[2;37m]\033[0m $file"
   done; echo "# "
 }
@@ -129,11 +129,11 @@ scmb_expand_args() {
         # Don't expand files or directories with numeric names
         args+=("$arg")
       else
-        args+=("$(_print_path "$relative" "$git_env_char$arg")")
+        args+=("$(_print_path "$relative" "$GIT_ENV_CHAR$arg")")
       fi
     elif [[ "$arg" =~ ^[0-9]+-[0-9]+$ ]]; then           # Expand ranges into $e{*} variables
       for i in $(eval echo {${arg/-/..}}); do
-        args+=("$(_print_path "$relative" "$git_env_char$i")")
+        args+=("$(_print_path "$relative" "$GIT_ENV_CHAR$i")")
       done
     else   # Otherwise, treat $arg as a normal string.
       args+=("$arg")
@@ -172,9 +172,9 @@ exec_scmb_expand_args() {
 # Clear numbered env variables
 git_clear_vars() {
   local i
-  for (( i=1; i<=$gs_max_changes; i++ )); do
+  for (( i=1; i<=$GS_MAX_CHANGES; i++ )); do
     # Stop clearing after first empty var
-    local env_var_i=${git_env_char}${i}
+    local env_var_i=${GIT_ENV_CHAR}${i}
     if [[ -z "$(eval echo "\${$env_var_i:-}")" ]]; then
       break
     else

--- a/lib/git/status_shortcuts_refactor.rb
+++ b/lib/git/status_shortcuts_refactor.rb
@@ -37,7 +37,7 @@ class GitStatus
   end
 
   def report
-    exit if all_changes.length > ENV["gs_max_changes"].to_i
+    exit if all_changes.length > ENV["GS_MAX_CHANGES"].to_i
     print_header
     print_groups
     puts filelist if @grouped_changes.any?
@@ -188,7 +188,7 @@ class GitStatus
   end
 
   def hotkey
-    "[*] => $#{ENV['git_env_char']}"
+    "[*] => $#{ENV['GIT_ENV_CHAR']}"
   end
 
   # used to delimit the left side of the screen - looks nice

--- a/lib/git/tools.sh
+++ b/lib/git/tools.sh
@@ -122,7 +122,7 @@ git_swap_remotes() {
   echo "Swapped $1 <-> $2"
 }
 # (use git fetch tab completion)
-if [ "$git_skip_shell_completion" != "yes" ]; then
+if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
   if [ "$shell" = "bash" ]; then
     complete -o default -o nospace -F _git_fetch git_swap_remotes
   fi

--- a/scm_breeze.sh
+++ b/scm_breeze.sh
@@ -21,6 +21,7 @@ fi
 if [[ -s "$HOME/.git.scmbrc" ]]; then
   # Load git config
   source "$HOME/.git.scmbrc"
+  source "$scmbDir/lib/git/compatibility.sh"
   source "$scmbDir/lib/git/helpers.sh"
   source "$scmbDir/lib/git/aliases.sh"
   source "$scmbDir/lib/git/keybindings.sh"

--- a/test/lib/git/compatibility_test.sh
+++ b/test/lib/git/compatibility_test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# SCM Breeze - Streamline your SCM workflow.
+# Copyright 2011 Nathan Broadbent (http://madebynathan.com). All Rights Reserved.
+# Released under the LGPL (GNU Lesser General Public License)
+# ------------------------------------------------------------------------------
+#
+# Unit tests for git/compatibility.sh
+
+export scmbDir="$(cd -P "$(dirname "$0")" && pwd)/../../.."
+
+# Zsh compatibility
+if [ -n "${ZSH_VERSION:-}" ]; then
+  shell="zsh"
+  SHUNIT_PARENT=$0
+  setopt shwordsplit
+else
+  # Bash needs this option so that 'alias' works in a non-interactive shell
+  shopt -s expand_aliases
+fi
+
+# Load test helpers
+source "$scmbDir/test/support/test_helper.sh"
+
+# Setup
+#-----------------------------------------------------------------------------
+oneTimeSetUp() {
+  # Save any existing variables to restore later
+  for var in GIT_ENV_CHAR GS_MAX_CHANGES GA_AUTO_REMOVE GIT_SETUP_ALIASES GIT_SKIP_SHELL_COMPLETION GIT_REPO_DIR GIT_STATUS_COMMAND; do
+    eval "orig_${var}=\${${var}:-}"
+    eval "unset ${var}"
+    # Also unset lowercase version
+    lower=$(echo "$var" | tr '[:upper:]' '[:lower:]')
+    eval "orig_${lower}=\${${lower}:-}"
+    eval "unset ${lower}"
+  done
+}
+
+oneTimeTearDown() {
+  # Restore original variables
+  for var in GIT_ENV_CHAR GS_MAX_CHANGES GA_AUTO_REMOVE GIT_SETUP_ALIASES GIT_SKIP_SHELL_COMPLETION GIT_REPO_DIR GIT_STATUS_COMMAND; do
+    eval "orig_val=\${orig_${var}:-}"
+    if [ -n "$orig_val" ]; then
+      eval "export ${var}=\"\$orig_val\""
+    else
+      eval "unset ${var}"
+    fi
+    # Also restore lowercase version
+    lower=$(echo "$var" | tr '[:upper:]' '[:lower:]')
+    eval "orig_val=\${orig_${lower}:-}"
+    if [ -n "$orig_val" ]; then
+      eval "export ${lower}=\"\$orig_val\""
+    else
+      eval "unset ${lower}"
+    fi
+  done
+}
+
+setUp() {
+  # Unset all variables before each test
+  for var in GIT_ENV_CHAR GS_MAX_CHANGES GA_AUTO_REMOVE GIT_SETUP_ALIASES GIT_SKIP_SHELL_COMPLETION GIT_REPO_DIR GIT_STATUS_COMMAND; do
+    eval "unset ${var}"
+    # Also unset lowercase version
+    lower=$(echo "$var" | tr '[:upper:]' '[:lower:]')
+    eval "unset ${lower}"
+  done
+}
+
+# Tests
+#-----------------------------------------------------------------------------
+
+test_uppercase_variables_not_overwritten() {
+  # Set uppercase variables
+  export GIT_ENV_CHAR="@"
+  export GS_MAX_CHANGES="150"
+
+  # Source compatibility script
+  source "$scmbDir/lib/git/compatibility.sh"
+
+  # Check that uppercase variables are not changed
+  assertEquals "@" "$GIT_ENV_CHAR"
+  assertEquals "150" "$GS_MAX_CHANGES"
+}
+
+test_lowercase_variables_converted_to_uppercase() {
+  # Set lowercase variables
+  export git_env_char="#"
+  export gs_max_changes="200"
+
+  # Source compatibility script
+  source "$scmbDir/lib/git/compatibility.sh"
+
+  # Check that uppercase variables are set from lowercase
+  assertEquals "#" "$GIT_ENV_CHAR"
+  assertEquals "200" "$GS_MAX_CHANGES"
+}
+
+test_uppercase_variables_take_precedence() {
+  # Set both uppercase and lowercase variables
+  export GIT_ENV_CHAR="@"
+  export git_env_char="#"
+  export GS_MAX_CHANGES="150"
+  export gs_max_changes="200"
+
+  # Source compatibility script
+  source "$scmbDir/lib/git/compatibility.sh"
+
+  # Check that uppercase variables take precedence
+  assertEquals "@" "$GIT_ENV_CHAR"
+  assertEquals "150" "$GS_MAX_CHANGES"
+}
+
+test_all_variables_converted() {
+  # Set all lowercase variables
+  export git_env_char="#"
+  export gs_max_changes="200"
+  export ga_auto_remove="true"
+  export git_setup_aliases="false"
+  export git_skip_shell_completion="true"
+  export git_repo_dir="/test/path"
+  export git_status_command="git status -sb"
+
+  # Source compatibility script
+  source "$scmbDir/lib/git/compatibility.sh"
+
+  # Check that all uppercase variables are set from lowercase
+  assertEquals "#" "$GIT_ENV_CHAR"
+  assertEquals "200" "$GS_MAX_CHANGES"
+  assertEquals "true" "$GA_AUTO_REMOVE"
+  assertEquals "false" "$GIT_SETUP_ALIASES"
+  assertEquals "true" "$GIT_SKIP_SHELL_COMPLETION"
+  assertEquals "/test/path" "$GIT_REPO_DIR"
+  assertEquals "git status -sb" "$GIT_STATUS_COMMAND"
+}
+
+# Load and run shUnit2
+source "$scmbDir/test/support/shunit2"

--- a/test/lib/git/repo_index_test.sh
+++ b/test/lib/git/repo_index_test.sh
@@ -28,7 +28,7 @@ source "$scmbDir/lib/git/repo_index.sh"
 oneTimeSetUp() {
   GIT_REPO_DIR=$(mktemp -d -t scm_breeze.XXXXXXXXXX)
   GIT_REPOS="/tmp/test_repo_1:/tmp/test_repo_11"
-  git_status_command="git status"
+  GIT_STATUS_COMMAND="git status"
 
   git_index_file="$GIT_REPO_DIR/.git_index"
 

--- a/test/lib/git/shell_shortcuts_test.sh
+++ b/test/lib/git/shell_shortcuts_test.sh
@@ -93,7 +93,7 @@ test_shell_command_wrapping() {
 }
 
 test_ls_with_file_shortcuts() {
-  export git_env_char="e"
+  export GIT_ENV_CHAR="e"
 
   TEST_DIR=$(mktemp -d -t scm_breeze.XXXXXXXXXX)
 

--- a/test/lib/git/status_shortcuts_test.sh
+++ b/test/lib/git/status_shortcuts_test.sh
@@ -28,9 +28,9 @@ source "$scmbDir/lib/git/status_shortcuts.sh"
 #-----------------------------------------------------------------------------
 oneTimeSetUp() {
   # Test Config
-  export git_env_char="e"
-  export gs_max_changes="20"
-  export ga_auto_remove="yes"
+  export GIT_ENV_CHAR="e"
+  export GS_MAX_CHANGES="20"
+  export GA_AUTO_REMOVE="yes"
 
   testRepo=$(mktemp -d -t scm_breeze.XXXXXXXXXX)
   testRepo=$(cd $testRepo && pwd -P)
@@ -279,7 +279,7 @@ test_git_status_shortcuts_merge_conflicts() {
 test_git_status_shortcuts_max_changes() {
   setupTestRepo
 
-  export gs_max_changes="5"
+  export GS_MAX_CHANGES="5"
 
   # Add 5 untracked files
   touch a b c d e
@@ -288,13 +288,13 @@ test_git_status_shortcuts_max_changes() {
     assertIncludes "$git_status" "\[$i\]" || return
   done
 
-  # 6 untracked files is more than $gs_max_changes
+  # 6 untracked files is more than $GS_MAX_CHANGES
   touch f
   git_status=$(git_status_shortcuts | strip_colors)
   assertNotIncludes "$git_status" "\[[0-9]*\]" || return
   assertIncludes "$git_status" "There were more than 5 changed files." || return
 
-  export gs_max_changes="20"
+  export GS_MAX_CHANGES="20"
 }
 
 test_git_add_shortcuts() {


### PR DESCRIPTION
When I originally wrote this I didn't know about: https://www.shellcheck.net/wiki/SC2154

> Note: This message only triggers for variables with lowercase characters in their name (foo and kFOO but not FOO) due to the standard convention of using lowercase variable names for unexported, local variables.

Whoops! So this change would fix a lot of shellcheck warnings in the scm_breeze source files, and also in my personal dotfiles (I have some custom functions that use scm_breeze.)

I would like to propose a backwards compatible fix so that we can use either `git_env_char` or `GIT_ENV_CHAR`  in `git.scmbrc`. This means that no-one has to change their existing config.

What do you think?