### PR TITLE
fix: gh-actions workflow broke after default branch rename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
[![facepalm](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/WjlTemxb6oA4PgZFmj08/90847050-76a2-4df0-ad36-97675936b7e2/facepalm.gif)](https://app.graphite.dev/settings/meme-library?org=voltusdev)