### PR TITLE
fix: Use git to figure out git repo.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   test:
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/lib/git/helpers.sh
+++ b/lib/git/helpers.sh
@@ -1,5 +1,7 @@
 function fail_if_not_git_repo() {
-  if ! $_git_cmd rev-parse --show-toplevel &> /dev/null; then
+  local gcmd=${_git_cmd:-git}
+
+  if ! "${gcmd}" rev-parse --show-toplevel &> /dev/null; then
     echo -e "\033[31mNot a git repository (or any of the parent directories)\033[0m"
     return 1
   fi

--- a/lib/git/helpers.sh
+++ b/lib/git/helpers.sh
@@ -1,14 +1,5 @@
-function find_in_cwd_or_parent() {
-  local slashes=${PWD//[^\/]/}; local directory=$PWD;
-  for (( n=${#slashes}; n>0; --n )); do
-    test -e "$directory/$1" && echo "$directory/$1" && return 0
-    directory="$directory/.."
-  done
-  return 1
-}
-
 function fail_if_not_git_repo() {
-  if ! find_in_cwd_or_parent ".git" > /dev/null; then
+  if ! $_git_cmd rev-parse --show-toplevel &> /dev/null; then
     echo -e "\033[31mNot a git repository (or any of the parent directories)\033[0m"
     return 1
   fi


### PR DESCRIPTION
I have a `.git` directory in my `$HOME` for some git hooks I have but it isn't a git repo and confuses me when I open a new terminal and forget I'm in my home but I get the 'There were more than 150 changed files.' I've included how it should look with the `/tmp` directory. See screenshot.

<img width="843" height="175" alt="ss 2025-08-04 at 12 33 52 PM" src="https://github.com/user-attachments/assets/d2eaf852-c298-40d8-bace-b67a54df2a5e" />

This removes the `find_in_cwd_or_parent` shell method in favor of just using a `git` command to determine. Seems simpler and more stable since it uses built-in git behaviour instead of rolling our own method.