### PR TITLE
Add support for git worktrees

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -30,7 +30,9 @@ function git(){
   case $1 in
     commit|blame|add|log|rebase|merge|difftool|switch)
       exec_scmb_expand_args "$_git_cmd" "$@";;
-    checkout|diff|rm|reset|restore)
+    checkout)
+      _scmb_git_checkout_shortcuts "${@:2}";;
+    diff|rm|reset|restore)
       exec_scmb_expand_args --relative "$_git_cmd" "$@";;
     branch)
       _scmb_git_branch_shortcuts "${@:2}";;


### PR DESCRIPTION
Adds numbering & aliasing for branches currently checked out by git worktrees. 

Previously, if you were to create a new git worktree, the branch does not get picked up with scm_breeze's numbering:
```
$ gco -b tmp && gco - && gco -b tmp2 && gco -
$ git worktree add /tmp/scm_breeze_tmp tmp
$ gb
* [1] main
+ tmp
  [3] tmp2
$ gco 2
error: pathspec '+ tmp' did not match any file(s) known to git
```

With this change, worktrees now appear to the user as "just another branch." Using scm_breeze aliases, you can swap branches seamlessly, using numeric aliases and without needing to manually remember & change directories. 

```
$ gb
* [1] main
+ [2] tmp
  [3] tmp2
$ gco 2
Switching to worktree: /tmp/scm_breeze_tmp
```

The `+` distinguishes between branches currently checked out in separate worktrees