### PR TITLE
Fix branch name to main in update_scm_breeze

### DIFF
--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -110,7 +110,7 @@ update_scm_breeze() {
   currDir=$PWD
   cd "$scmbDir"
   oldHEAD=$(git rev-parse HEAD 2> /dev/null)
-  git pull origin master
+  git pull origin main
   # Reload latest version of '_create_or_patch_scmbrc' function
   source "$scmbDir/lib/scm_breeze.sh"
   _create_or_patch_scmbrc $oldHEAD


### PR DESCRIPTION
This PR updates the `git pull` command in `update_scm_breeze` to use `main` instead of `master`.