### PR TITLE
Fix _safe_eval not found error in non-interactive shells

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -171,7 +171,13 @@ _print_path() {
 exec_scmb_expand_args() {
   local args
   eval "args=$(scmb_expand_args "$@")"  # populate $args array
-  _safe_eval "${args[@]}"
+  # Fall back to direct execution if _safe_eval isn't available
+  # (e.g., in non-interactive shells or tools like Claude Code)
+  if type _safe_eval > /dev/null 2>&1; then
+    _safe_eval "${args[@]}"
+  else
+    "${args[@]}"
+  fi
 }
 
 # Clear numbered env variables


### PR DESCRIPTION
## Problem

When using tools that spawn non-interactive shells (like [Claude Code CLI](https://github.com/anthropics/claude-code)), git commands fail with:

```
zsh: command not found: _safe_eval
```

This happens when running any git command that SCM Breeze intercepts (like `git log`, `git commit`, `git add`, etc.).

## Root Cause

SCM Breeze's `git` function wrapper calls `exec_scmb_expand_args`, which in turn calls `_safe_eval`. However, in some environments, the shell may have the `git` function defined (from a parent interactive shell session) but `_safe_eval` may not be available because `lib/scm_breeze.sh` wasn't fully sourced.

The call chain is:
1. `git log ...` → SCM Breeze's `git()` function (from `lib/git/aliases.sh`)
2. `git()` → `exec_scmb_expand_args` (for commands like `log`, `commit`, `add`, etc.)
3. `exec_scmb_expand_args` → `_safe_eval` ❌ **not found**

## Solution

Add a fallback in `exec_scmb_expand_args` to execute commands directly when `_safe_eval` is not available:

```bash
if type _safe_eval > /dev/null 2>&1; then
  _safe_eval "${args[@]}"
else
  "${args[@]}"
fi
```

This preserves the safe eval behavior when available while allowing SCM Breeze to work gracefully in environments where `_safe_eval` isn't loaded.

## Testing

- Normal interactive shell: Works as before (uses `_safe_eval`)
- Non-interactive shell (Claude Code): Falls back to direct execution
- No breaking changes to existing functionality