### PR TITLE
Fix find_binary function for zsh compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   test:
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31.6.1
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixos-unstable

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -94,6 +94,7 @@ _alias "$exec_scmb_expand_args_alias" 'exec_scmb_expand_args'
 _alias "$git_show_files_alias"        'git_show_affected_files'
 _alias "$git_commit_all_alias"        'git_commit_all'
 _alias "$git_grep_shortcuts_alias"    'git_grep_shortcuts'
+_alias "$git_reset_last_commit"       'git_reset_last_commit'
 
 # Git Index alias
 _alias "$git_index_alias"             'git_index'
@@ -145,7 +146,6 @@ if [ "$GIT_SETUP_ALIASES" = "yes" ]; then
   __git_alias "$git_rebase_interactive_alias"       'git' 'rebase' '-i'
   __git_alias "$git_rebase_alias_continue"          'git' 'rebase' '--continue'
   __git_alias "$git_rebase_alias_abort"             'git' 'rebase' '--abort'
-  __git_alias "$git_reset_last_commit"              'git' 'reset HEAD~'
   __git_alias "$git_top_level_alias"                'git' 'rev-parse' '--show-toplevel'
   __git_alias "$git_merge_alias"                    'git' 'merge'
   __git_alias "$git_merge_no_fast_forward_alias"    'git' 'merge' '--no-ff'

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -30,7 +30,9 @@ function git(){
   case $1 in
     commit|blame|add|log|rebase|merge|difftool|switch)
       exec_scmb_expand_args "$_git_cmd" "$@";;
-    checkout|diff|rm|reset|restore)
+    checkout)
+      _scmb_git_checkout_shortcuts "${@:2}";;
+    diff|rm|reset|restore)
       exec_scmb_expand_args --relative "$_git_cmd" "$@";;
     branch)
       _scmb_git_branch_shortcuts "${@:2}";;

--- a/lib/git/helpers.sh
+++ b/lib/git/helpers.sh
@@ -1,5 +1,7 @@
 function fail_if_not_git_repo() {
-  if ! $_git_cmd rev-parse --show-toplevel &> /dev/null; then
+  local gcmd=${_git_cmd:-git}
+
+  if ! "${gcmd}" rev-parse --show-toplevel &> /dev/null; then
     echo -e "\033[31mNot a git repository (or any of the parent directories)\033[0m"
     return 1
   fi

--- a/lib/git/helpers.sh
+++ b/lib/git/helpers.sh
@@ -1,14 +1,5 @@
-function find_in_cwd_or_parent() {
-  local slashes=${PWD//[^\/]/}; local directory=$PWD;
-  for (( n=${#slashes}; n>0; --n )); do
-    test -e "$directory/$1" && echo "$directory/$1" && return 0
-    directory="$directory/.."
-  done
-  return 1
-}
-
 function fail_if_not_git_repo() {
-  if ! find_in_cwd_or_parent ".git" > /dev/null; then
+  if ! $_git_cmd rev-parse --show-toplevel &> /dev/null; then
     echo -e "\033[31mNot a git repository (or any of the parent directories)\033[0m"
     return 1
   fi

--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -98,13 +98,6 @@ fi
 # Function wrapper around 'll'
 # Adds numbered shortcuts to output of ls -l, just like 'git status'
 if [ "$shell_ls_aliases_enabled" = "true" ] && builtin command -v ruby >/dev/null 2>&1; then
-  # BSD ls is different to Linux (GNU) ls
-  # Test for BSD ls
-  if ! (ls --version 2>/dev/null || echo "BSD") | grep GNU >/dev/null 2>&1; then
-    # ls is BSD
-    _ls_bsd="BSD"
-  fi
-
   # Test if readlink supports -f option, test for greadlink on Mac, then fallback to perl
   if \readlink -f / >/dev/null 2>&1; then
     _abs_path_command=(readlink -f)
@@ -117,6 +110,12 @@ if [ "$shell_ls_aliases_enabled" = "true" ] && builtin command -v ruby >/dev/nul
   unalias ll >/dev/null 2>&1
   unset -f ll >/dev/null 2>&1
   function ls_with_file_shortcuts {
+    # BSD ls is different to Linux (GNU) ls
+    if ! (\ls --version 2>/dev/null || echo "BSD") | grep GNU >/dev/null 2>&1; then
+      # ls is BSD
+      local _ls_bsd="BSD"
+    fi
+
     local ll_output
     local ll_command # Ensure sort ordering of the two invocations is the same
     if [ "$_ls_bsd" != "BSD" ]; then
@@ -124,7 +123,7 @@ if [ "$shell_ls_aliases_enabled" = "true" ] && builtin command -v ruby >/dev/nul
       ll_output="$("${ll_command[@]}" -l --color "$@")"
     else
       ll_command=(\ls)
-      ll_output="$(CLICOLOR_FORCE=1 "${ll_command[@]}" -lG "$@")"
+      ll_output="$("${ll_command[@]}" -lG --color=always "$@")"
     fi
 
     if breeze_shell_is "zsh"; then
@@ -215,7 +214,7 @@ EOF
     if [ -z $_ls_bsd ]; then
       ll_files="$(QUOTING_STYLE=literal "${ll_command[@]}" --color=never "$@")"
     else
-      ll_files="$("${ll_command[@]}" "$@")"
+      ll_files="$("${ll_command[@]}" --color=never "$@")"
     fi
 
     local IFS=$'\n'

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -96,7 +96,7 @@ function _safe_eval() {
 }
 
 find_binary() {
-  if breeze_shell_is "bash"; then
+  if breeze_shell_is "zsh"; then
     builtin type -p "$1" | sed "s/$1 is //" | head -1
   else
     builtin type -P "$1"

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -110,7 +110,7 @@ update_scm_breeze() {
   currDir=$PWD
   cd "$scmbDir"
   oldHEAD=$(git rev-parse HEAD 2> /dev/null)
-  git pull origin master
+  git pull origin main
   # Reload latest version of '_create_or_patch_scmbrc' function
   source "$scmbDir/lib/scm_breeze.sh"
   _create_or_patch_scmbrc $oldHEAD

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -97,9 +97,11 @@ function _safe_eval() {
 
 find_binary() {
   if breeze_shell_is "zsh"; then
-    builtin type -p "$1" | sed "s/$1 is //" | head -1
+    # zsh doesn't support type -p, use whence -p instead
+    builtin whence -p "$1"
   else
-    builtin type -P "$1"
+    # bash supports type -p
+    builtin type -p "$1" | sed "s/$1 is //" | head -1
   fi
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `find_binary` function that causes errors when running git commands in zsh.

## Problem

The current implementation uses incorrect `type` command options for both shells:
- Line 100: Uses `type -p` which doesn't work in zsh (bash-only syntax)
- Line 102: Uses `type -P` (capital P) which doesn't exist in bash

This causes the error:
```
find_binary:type:4: bad option: -P
```

## Solution

Use the correct command for each shell:
- **zsh**: `builtin whence -p` (the zsh equivalent of bash's `type -p`)
- **bash**: `builtin type -p` (works correctly in bash)

## Testing

Tested in zsh on macOS. After this fix:
- `gs` (git status) works without errors
- `git` commands execute properly
- No more "bad option: -P" errors

## Changes

- Fixed shell-specific command usage in `find_binary()` function
- Added clarifying comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)