### PR TITLE
Fix: Don't expand numeric arguments. Fix "fatal: '': not an integer" errors

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -128,8 +128,21 @@ scmb_expand_args() {
 
   local args
   args=()  # initially empty array. zsh 5.0.2 from Ubuntu 14.04 requires this to be separated
+  local prev_arg=""
   for arg in "$@"; do
-    if [[ "$arg" =~ ^[0-9]{0,4}$ ]] ; then      # Substitute $e{*} variables for any integers
+    # Skip expansion if previous arg was a flag expecting an integer value.
+    # Without this, "git log -n 30" would try to expand "30" to "$e30" (a file shortcut),
+    # which fails with "fatal: '': not an integer" when $e30 is empty.
+    local skip_expand=0
+    if [[ "$prev_arg" =~ ^-[nCAB]$ ]] || \
+       [[ "$prev_arg" =~ ^--(max-count|skip|depth)$ ]]; then
+      skip_expand=1
+    fi
+
+    if [[ $skip_expand -eq 1 ]]; then
+      # Don't expand - this is an integer argument for a flag
+      args+=("$arg")
+    elif [[ "$arg" =~ ^[0-9]{0,4}$ ]] ; then      # Substitute $e{*} variables for any integers
       if [ -e "$arg" ]; then
         # Don't expand files or directories with numeric names
         args+=("$arg")
@@ -143,6 +156,7 @@ scmb_expand_args() {
     else   # Otherwise, treat $arg as a normal string.
       args+=("$arg")
     fi
+    prev_arg="$arg"
   done
 
   # "declare -p" with zsh 5.0.2 on Ubuntu 14.04 creates a string that it cannot process:


### PR DESCRIPTION
AI coding agents like to pass the `-n` flag to limit git output. This was breaking SCM Breeze's git() function wrapper.

Problem: The scmb_expand_args function was expanding numeric arguments like 30 in git log -n 30 to $e30 (a file shortcut variable). When $e30 was empty, it became an empty string, causing fatal: '': not an integer.

Fix: Added logic to skip expansion when the previous argument is a flag that expects an integer value (-n, -C, -A, -B, --max-count, --skip, --depth).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed argument processing to correctly handle numeric values when they follow command flags (such as -n, -C, -A, -B, and their long-form equivalents), preventing incorrect variable expansion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->