### PR TITLE
fix(zsh): fix find_binary type -P error in zsh

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -25,7 +25,7 @@ if type hub > /dev/null 2>&1; then export _git_cmd="hub"; fi
 #if type gh  > /dev/null 2>&1; then export _git_cmd="gh"; fi
 
 # Create 'git' function that calls hub if defined, and expands all numeric arguments
-function git(){
+git(){
   # Only expand args for git commands that deal with paths or branches
   case $1 in
     commit|blame|add|log|rebase|merge|difftool|switch)

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -11,7 +11,7 @@
 # Function wrapper around 'll'
 # Adds numbered shortcuts to output of ls -l, just like 'git status'
 unalias $git_branch_alias > /dev/null 2>&1; unset -f $git_branch_alias > /dev/null 2>&1
-function _scmb_git_branch_shortcuts {
+_scmb_git_branch_shortcuts() {
   fail_if_not_git_repo || return 1
 
   # Fall back to normal git branch, if any unknown args given

--- a/lib/git/helpers.sh
+++ b/lib/git/helpers.sh
@@ -1,4 +1,4 @@
-function find_in_cwd_or_parent() {
+find_in_cwd_or_parent() {
   local slashes=${PWD//[^\/]/}; local directory=$PWD;
   for (( n=${#slashes}; n>0; --n )); do
     test -e "$directory/$1" && echo "$directory/$1" && return 0
@@ -7,7 +7,7 @@ function find_in_cwd_or_parent() {
   return 1
 }
 
-function fail_if_not_git_repo() {
+fail_if_not_git_repo() {
   if ! find_in_cwd_or_parent ".git" > /dev/null; then
     echo -e "\033[31mNot a git repository (or any of the parent directories)\033[0m"
     return 1
@@ -18,6 +18,6 @@ function fail_if_not_git_repo() {
 bin_path() {
   if [[ -n ${ZSH_VERSION:-} ]];
     then builtin whence -cp "$1" 2> /dev/null
-    else builtin type -P "$1"
+    else builtin type -p "$1"
   fi
 }

--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -50,7 +50,7 @@
 #     # => cd $GIT_REPO_DIR
 
 
-function git_index() {
+git_index() {
   local IFS=$'\n'
   if [ -z "$1" ]; then
     # Just change to $GIT_REPO_DIR if no params given.
@@ -123,7 +123,7 @@ _git_index_dirs_without_home() {
 }
 
 # Recursively searches for git repos in $GIT_REPO_DIR
-function _find_git_repos() {
+_find_git_repos() {
   # Find all unarchived projects
   local IFS=$'\n'
   for repo in $(find -L "$GIT_REPO_DIR" -maxdepth 3 -name ".git" -type d \! -wholename '*/archive/*'); do
@@ -133,7 +133,7 @@ function _find_git_repos() {
 }
 
 # List all submodules for a git repo, if any.
-function _find_git_submodules() {
+_find_git_submodules() {
   if [ -e "$1/../.gitmodules" ]; then
     \grep "\[submodule" "$1/../.gitmodules" | sed "s%\[submodule \"%${1%/.git}/%g" | sed "s/\"]//g"
   fi
@@ -141,7 +141,7 @@ function _find_git_submodules() {
 
 
 # Rebuilds index of git repos in $GIT_REPO_DIR.
-function _rebuild_git_index() {
+_rebuild_git_index() {
   if [ "$1" != "--silent" ]; then echo -e "== Scanning $GIT_REPO_DIR for git repos & submodules..."; fi
   # Get repos from src dir and custom dirs, then sort by basename
   local IFS=$'\n'
@@ -155,27 +155,27 @@ function _rebuild_git_index() {
 }
 
 # Build index if empty
-function _check_git_index() {
+_check_git_index() {
   if [ ! -f "$GIT_REPO_DIR/.git_index" ]; then
     _rebuild_git_index --silent
   fi
 }
 
 # Produces a count of repos in the tab completion index (excluding commands)
-function _git_index_count() {
+_git_index_count() {
   echo $(sed -e "s/--.*//" "$GIT_REPO_DIR/.git_index" | \grep . | wc -l)
 }
 
 # Returns the current $GIT_BINARY branch (returns nothing if not a git repository)
-function is_git_dirty {
+is_git_dirty() {
     [[ $($GIT_BINARY status 2> /dev/null | tail -n1) != "nothing to commit (working directory clean)" ]] && echo "*"
  }
-function parse_git_branch {
+parse_git_branch() {
     git rev-parse --abbrev-ref HEAD 2> /dev/null
 }
 
 # If the working directory is clean, update the git repository. Otherwise, show changes.
-function _git_index_status_if_dirty() {
+_git_index_status_if_dirty() {
   if ! [ `git status --porcelain | wc -l` -eq 0 ]; then
     # Fall back to 'git status' if git status alias isn't configured
     if type $GIT_STATUS_COMMAND 2>&1 | \grep -qv "not found"; then
@@ -254,14 +254,14 @@ _git_index_update_all_branches() {
 # Updates all git repositories with clean working directories.
 # Use the following cron configuration:
 # */10 * * * * /bin/bash -c '. $HOME/.bashrc && git_index --rebuild && git_index --update-all'
-function _git_index_update_all() {
+_git_index_update_all() {
   echo -e "== Safely updating all local branches in $_bld_col$(_git_index_count)$_txt_col repos...\n"
   _git_index_batch_cmd _git_index_update_all_branches
 }
 
 
 # Runs a command for all git repos
-function _git_index_batch_cmd() {
+_git_index_batch_cmd() {
   cwd="$PWD"
   if [ -n "$1" ]; then
     echo -e "== Running command for $_bld_col$(_git_index_count)$_txt_col repos...\n"
@@ -280,7 +280,7 @@ function _git_index_batch_cmd() {
 
 if breeze_shell_is "bash"; then
 	# Bash tab completion function for git_index()
-	function _git_index_tab_completion() {
+	_git_index_tab_completion() {
 		_check_git_index
 		local curw IFS=$'\n'
 		COMPREPLY=()
@@ -312,7 +312,7 @@ if breeze_shell_is "bash"; then
 		return 0
 	}
 else  # Zsh tab completion function for git_index()
-	function _git_index_tab_completion() {
+	_git_index_tab_completion() {
 		typeset -A opt_args
 		local state state_descr context line
 

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -169,6 +169,10 @@ _print_path() {
 # Execute a command with expanded args, e.g. Delete files 6 to 12: $ ge rm 6-12
 # Fails if command is a number or range (probably not worth fixing)
 exec_scmb_expand_args() {
+  # Fallback for _safe_eval if it is not defined (e.g. in some restricted environments)
+  if ! type _safe_eval >/dev/null 2>&1; then
+    _safe_eval() { eval $(token_quote "$@"); }
+  fi
   local args
   eval "args=$(scmb_expand_args "$@")"  # populate $args array
   _safe_eval "${args[@]}"

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -169,10 +169,13 @@ _print_path() {
 # Execute a command with expanded args, e.g. Delete files 6 to 12: $ ge rm 6-12
 # Fails if command is a number or range (probably not worth fixing)
 exec_scmb_expand_args() {
-  # Fallback for _safe_eval if it is not defined (e.g. in some restricted environments)
-  if ! type _safe_eval >/dev/null 2>&1; then
-    _safe_eval() { eval $(token_quote "$@"); }
-  fi
+  local required_fn
+  for required_fn in _safe_eval token_quote breeze_shell_is; do
+    if ! type "$required_fn" >/dev/null 2>&1; then
+      echo "SCM Breeze error: required function '$required_fn' is not loaded; ensure lib/scm_breeze.sh has been sourced." >&2
+      return 1
+    fi
+  done
   local args
   eval "args=$(scmb_expand_args "$@")"  # populate $args array
   _safe_eval "${args[@]}"

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -99,7 +99,7 @@ find_binary() {
   if breeze_shell_is "bash"; then
     builtin type -p "$1" | sed "s/$1 is //" | head -1
   else
-    builtin type -P "$1"
+    builtin type -p "$1"
   fi
 }
 

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -54,7 +54,7 @@ _alias() {
 }
 
 # Quote the contents of "$@"
-function token_quote {
+token_quote() {
     # Older versions of {ba,z}sh don't support the built-in quoting, so fall back to printf %q
   local quoted
   quoted=()  # Assign separately for zsh 5.0.2 of Ubuntu 14.04
@@ -79,7 +79,7 @@ function token_quote {
 # Quote "$@" before `eval` to prevent arbitrary code execution.
 # Eg, the following will run `date`:
 # evil() { eval "$@"; }; evil "echo" "foo;date"
-function _safe_eval() {
+_safe_eval() {
   eval $(token_quote "$@")
 
   # Keep this code for use when minimum versions of {ba,z}sh can be increased.

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -99,7 +99,7 @@ find_binary() {
   if breeze_shell_is "bash"; then
     builtin type -p "$1" | sed "s/$1 is //" | head -1
   else
-    builtin type -p "$1"
+    builtin type -p "$1" | sed "s/$1 is //" | head -1
   fi
 }
 

--- a/scm_breeze_aliases
+++ b/scm_breeze_aliases
@@ -1,0 +1,5 @@
+alias gf='
+  repo=$(basename "$(git rev-parse --show-toplevel)" .git)
+  git remote set-url origin git@github.com:johnyoonh/${repo}.git
+  echo "origin ➜ johnyoonh/${repo}"
+'

--- a/scm_breeze_aliases
+++ b/scm_breeze_aliases
@@ -1,5 +1,0 @@
-alias gf='
-  repo=$(basename "$(git rev-parse --show-toplevel)" .git)
-  git remote set-url origin git@github.com:johnyoonh/${repo}.git
-  echo "origin ➜ johnyoonh/${repo}"
-'


### PR DESCRIPTION
The find_binary function uses type -P which is not supported in zsh. This fix changes it to type -p which works in both bash and zsh.