### PR TITLE
Fix autocd support for git worktrees

### DIFF
--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -50,7 +50,7 @@ function _scmb_git_checkout_shortcuts {
   fi
 
   if [[ "$1" =~ ^[0-9]+$ ]]; then
-    local branch_var="${git_env_char}$1"
+    local branch_var="${GIT_ENV_CHAR}$1"
     local branch=$(eval echo "\$$branch_var")
 
     if [ -n "$branch" ]; then


### PR DESCRIPTION
https://github.com/scmbreeze/scm_breeze/pull/353 introduced support for git worktrees. However, autocd seems broken on unix systems as bash variables
are case sensitive on unix.

Therefore, when trying to cd into a worktree through `gco 1`, the error `fatal: 'worktree-name' is already checked out at '/path/to/worktree`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable reference in git branch checkout shortcuts, ensuring numbered shortcuts correctly resolve target branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->