### PR TITLE
mcrockett/Improve worktree inside git checkout.

### DIFF
--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -49,25 +49,25 @@ function _scmb_git_checkout_shortcuts {
     return $?
   fi
 
+  # If only branch then check if it's a worktree
   if [[ "$1" =~ ^[0-9]+$ ]]; then
     local branch_var="${git_env_char}$1"
-    local branch=$(eval echo "\$$branch_var")
+    local branch=$(exec_scmb_expand_args echo "${branch_var}")
 
     if [ -n "$branch" ]; then
-      if $_git_cmd worktree list --porcelain 2>/dev/null | grep -q "^branch refs/heads/$branch$"; then
-        local worktree_path=$($_git_cmd worktree list --porcelain | awk "
-          /^worktree / {
-            path = substr(\$0, 10); next
-          }
-          /^branch refs\/heads\/$branch$/ {
-            print path; exit
-          }
-        ")
-        if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
-          echo "Switching to worktree: $worktree_path"
-          cd "$worktree_path"
-          return $?
-        fi
+      local worktree_path=$($_git_cmd worktree list --porcelain 2>/dev/null | awk -v target_branch="$branch" '
+        /^worktree / { path = substr($0, 10); next }
+        /^branch / {
+          ref = substr($0, 8)
+          sub(/^refs\/heads\//, "", ref)
+          if (ref == target_branch) { print path; exit }
+        }
+      ')
+
+      if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
+        echo "Switching to worktree: $worktree_path"
+        cd "$worktree_path"
+        return $?
       fi
     fi
   fi


### PR DESCRIPTION
### Overview
I was trying to use `git checkout mcrockett/cats` for a worktree and have it `cd` to the directory. It was broken in two ways:
- The `/` in the name broke the `awk` command
- The `echo ${branch_var}` didn't honor scm breeze's argument expand

### What
- `worktree` `awk` handles `/` in branch name
- `worktree` handles `gco 2` expansion correctly
- Slight performance improvement by single call to `worktree list`

### Why
- I like `/` in my branches 😄 
- I ❤️ the scm breeze concept of expansion
- Sometimes I like to accidentally make performance better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved git worktree detection for branch shortcuts—numeric branch arguments now more reliably identify and switch to the corresponding worktree directory.
* Enhanced variable expansion consistency when resolving branch names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->