### PR TITLE
mcrockett/Fix ClaudeCode ignoring _ functions as "private"

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -31,11 +31,11 @@ function git(){
     commit|blame|add|log|rebase|merge|difftool|switch)
       exec_scmb_expand_args "$_git_cmd" "$@";;
     checkout)
-      _scmb_git_checkout_shortcuts "${@:2}";;
+      __scmb_git_checkout_shortcuts "${@:2}";;
     diff|rm|reset|restore)
       exec_scmb_expand_args --relative "$_git_cmd" "$@";;
     branch)
-      _scmb_git_branch_shortcuts "${@:2}";;
+      __scmb_git_branch_shortcuts "${@:2}";;
     *)
       "$_git_cmd" "$@";;
   esac

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -11,7 +11,7 @@
 # Function wrapper around 'll'
 # Adds numbered shortcuts to output of ls -l, just like 'git status'
 unalias $git_branch_alias > /dev/null 2>&1; unset -f $git_branch_alias > /dev/null 2>&1
-function _scmb_git_branch_shortcuts {
+function __scmb_git_branch_shortcuts {
   fail_if_not_git_repo || return 1
 
   # Fall back to normal git branch, if any unknown args given
@@ -41,7 +41,7 @@ EOF
   done
 }
 
-function _scmb_git_checkout_shortcuts {
+function __scmb_git_checkout_shortcuts {
   fail_if_not_git_repo || return 1
 
   if [ -z "$1" ]; then
@@ -75,11 +75,11 @@ function _scmb_git_checkout_shortcuts {
   exec_scmb_expand_args $_git_cmd checkout "$@"
 }
 
-__git_alias "$git_branch_alias"              "_scmb_git_branch_shortcuts" ""
-__git_alias "$git_branch_all_alias"          "_scmb_git_branch_shortcuts" "-a"
-__git_alias "$git_branch_move_alias"         "_scmb_git_branch_shortcuts" "-m"
-__git_alias "$git_branch_delete_alias"       "_scmb_git_branch_shortcuts" "-d"
-__git_alias "$git_branch_delete_force_alias" "_scmb_git_branch_shortcuts" "-D"
+__git_alias "$git_branch_alias"              "__scmb_git_branch_shortcuts" ""
+__git_alias "$git_branch_all_alias"          "__scmb_git_branch_shortcuts" "-a"
+__git_alias "$git_branch_move_alias"         "__scmb_git_branch_shortcuts" "-m"
+__git_alias "$git_branch_delete_alias"       "__scmb_git_branch_shortcuts" "-d"
+__git_alias "$git_branch_delete_force_alias" "__scmb_git_branch_shortcuts" "-D"
 
 # Define completions for git branch shortcuts
 if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -171,7 +171,7 @@ _print_path() {
 exec_scmb_expand_args() {
   local args
   eval "args=$(scmb_expand_args "$@")"  # populate $args array
-  _safe_eval "${args[@]}"
+  __safe_eval "${args[@]}"
 }
 
 # Clear numbered env variables

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -79,7 +79,7 @@ function token_quote {
 # Quote "$@" before `eval` to prevent arbitrary code execution.
 # Eg, the following will run `date`:
 # evil() { eval "$@"; }; evil "echo" "foo;date"
-function _safe_eval() {
+function __safe_eval() {
   eval $(token_quote "$@")
 
   # Keep this code for use when minimum versions of {ba,z}sh can be increased.

--- a/test/lib/scm_breeze_test.sh
+++ b/test/lib/scm_breeze_test.sh
@@ -16,9 +16,9 @@ source "$scmbDir/lib/scm_breeze.sh"
 #-----------------------------------------------------------------------------
 
 test__safe_eval() {
-  assertEquals "runs eval with simple words" 'one two three' "$(_safe_eval token_quote one two three)"
-  assertEquals "quotes spaces" 'a b\ c d' "$(_safe_eval token_quote a b\ c d)"
-  assertEquals "quotes special chars" 'a\ b \$dollar \\slash c\ d' "$(_safe_eval token_quote a\ b '$dollar' '\slash' c\ d)"
+  assertEquals "runs eval with simple words" 'one two three' "$(__safe_eval token_quote one two three)"
+  assertEquals "quotes spaces" 'a b\ c d' "$(__safe_eval token_quote a b\ c d)"
+  assertEquals "quotes special chars" 'a\ b \$dollar \\slash c\ d' "$(__safe_eval token_quote a\ b '$dollar' '\slash' c\ d)"
 }
 
 


### PR DESCRIPTION
### Problem
ClaudeCode removes `_blah` functions in it's snapshot since it views them as 'private'

#### What
- Rename all 'runtime' functions as non-private `__` names

#### Why
- This is probably more correct generally since these functions _could_ be used outside scm_breeze and also fixes my issues with claude code in my shell not working b/c it couldn't find the `_safe_eval` function (and others)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to maintain consistency and clarity across the codebase. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->