### PR TITLE
Fix: Don't expand numeric arguments. Fix "fatal: '': not an integer" errors

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -128,8 +128,21 @@ scmb_expand_args() {
 
   local args
   args=()  # initially empty array. zsh 5.0.2 from Ubuntu 14.04 requires this to be separated
+  local prev_arg=""
   for arg in "$@"; do
-    if [[ "$arg" =~ ^[0-9]{0,4}$ ]] ; then      # Substitute $e{*} variables for any integers
+    # Skip expansion if previous arg was a flag expecting an integer value.
+    # Without this, "git log -n 30" would try to expand "30" to "$e30" (a file shortcut),
+    # which fails with "fatal: '': not an integer" when $e30 is empty.
+    local skip_expand=0
+    if [[ "$prev_arg" =~ ^-[nCAB]$ ]] || \
+       [[ "$prev_arg" =~ ^--(max-count|skip|depth)$ ]]; then
+      skip_expand=1
+    fi
+
+    if [[ $skip_expand -eq 1 ]]; then
+      # Don't expand - this is an integer argument for a flag
+      args+=("$arg")
+    elif [[ "$arg" =~ ^[0-9]{0,4}$ ]] ; then      # Substitute $e{*} variables for any integers
       if [ -e "$arg" ]; then
         # Don't expand files or directories with numeric names
         args+=("$arg")
@@ -143,6 +156,7 @@ scmb_expand_args() {
     else   # Otherwise, treat $arg as a normal string.
       args+=("$arg")
     fi
+    prev_arg="$arg"
   done
 
   # "declare -p" with zsh 5.0.2 on Ubuntu 14.04 creates a string that it cannot process:

--- a/test/lib/git/status_shortcuts_test.sh
+++ b/test/lib/git/status_shortcuts_test.sh
@@ -86,6 +86,36 @@ test_scmb_expand_args() {
       eval args="$(scmb_expand_args 7 1-1 8)"
       token_quote "${args[@]}"
     )"
+  assertEquals "$error" '-n 1 three six' \
+    "$(
+      eval args="$(scmb_expand_args -n 1 3 6)"
+      token_quote "${args[@]}"
+    )"
+  assertEquals "$error" '-n1 three six' \
+    "$(
+      eval args="$(scmb_expand_args -n1 3 6)"
+      token_quote "${args[@]}"
+    )"
+  assertEquals "$error" 'one -n 3 six' \
+    "$(
+      eval args="$(scmb_expand_args 1 -n 3 6)"
+      token_quote "${args[@]}"
+    )"
+  assertEquals "$error" 'one -n3 six' \
+    "$(
+      eval args="$(scmb_expand_args 1 -n3 6)"
+      token_quote "${args[@]}"
+    )"
+  assertEquals "$error" 'one three -n 6' \
+    "$(
+      eval args="$(scmb_expand_args 1 3 -n 6)"
+      token_quote "${args[@]}"
+    )"
+  assertEquals "$error" 'one three -n6' \
+    "$(
+      eval args="$(scmb_expand_args 1 3 -n6)"
+      token_quote "${args[@]}"
+    )"
 
   # Keep this code for use when minimum versions of {ba,z}sh can be increased.
   # See token_quote() source and https://github.com/scmbreeze/scm_breeze/issues/260


### PR DESCRIPTION
1. ##361 with tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed argument expansion to correctly distinguish between numeric flag parameters and file shortcuts, preventing numeric values passed to command-line flags from being misinterpreted as shortcut numbers.

* **Tests**
  * Added comprehensive test coverage for argument expansion scenarios with flags in various positions and spacing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->