### PR TITLE
Five PRs from my `breezier` branch that ghthor recommended I open here :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ features.
 
 - [SCM Breeze](#scm-breeze)
   - [Installation](#installation)
+  - [Docker sandbox](#docker-sandbox)
     - [File Shortcuts](#file-shortcuts)
       - [Git Status Shortcuts:](#git-status-shortcuts)
       - ['ls' shortcuts:](#ls-shortcuts)
@@ -49,6 +50,27 @@ to your `.bashrc` or `.zshrc`:
 `[ -s "$HOME/.scm_breeze/scm_breeze.sh" ] && source "$HOME/.scm_breeze/scm_breeze.sh"`
 
 **Note:** You need to install ruby for some SCM Breeze commands to work. This also improves performance. See [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/) for installation information.
+
+## Docker sandbox
+
+A small Docker setup is included under `docker/` for trying SCM Breeze in an
+isolated environment, with no impact on your host shell config. Useful for
+testing changes or kicking the tires before installing.
+
+Build and run from the repo root:
+
+```bash
+docker build -t scm_breeze-sandbox docker/
+docker run --rm -it -v "$PWD:/workspace" scm_breeze-sandbox
+```
+
+Inside the container:
+
+- `/workspace` is the bind-mounted repo (host edits are live)
+- `~/sandbox-repo` is a throwaway git repo pre-populated with staged,
+  unstaged, and untracked changes for experimentation
+- Run the test suite with `cd /workspace && ./run_tests.sh`
+- Run `zsh` to try SCM Breeze under zsh
 
 ### File Shortcuts
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+      git \
+      bash \
+      zsh \
+      ruby \
+      grep \
+      sed \
+      gawk \
+      coreutils \
+      findutils \
+      ncurses \
+      shunit2 \
+      patch
+
+RUN adduser -D -s /bin/bash dev
+USER dev
+WORKDIR /home/dev
+
+# install.sh appends to existing rc files only (uses `-s`, requires non-empty).
+RUN printf '# scm_breeze sandbox\n' > .bashrc \
+ && printf '# scm_breeze sandbox\n' > .bash_profile \
+ && printf '# scm_breeze sandbox\n' > .zshrc
+
+RUN git config --global user.name  "scm_breeze sandbox" \
+ && git config --global user.email "sandbox@example.com" \
+ && git config --global init.defaultBranch main
+
+COPY --chown=dev:dev entrypoint.sh /home/dev/entrypoint.sh
+RUN chmod +x /home/dev/entrypoint.sh
+
+ENV SHELL=/bin/bash
+ENTRYPOINT ["/home/dev/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+if [ ! -f "$HOME/.scm_breeze_installed" ]; then
+  if [ -d /workspace ] && [ -f /workspace/install.sh ]; then
+    bash /workspace/install.sh >/dev/null || true
+    touch "$HOME/.scm_breeze_installed"
+  else
+    echo "warning: /workspace/install.sh not found — did you bind-mount the repo to /workspace?" >&2
+  fi
+fi
+
+SANDBOX_REPO="$HOME/sandbox-repo"
+if [ ! -d "$SANDBOX_REPO/.git" ]; then
+  mkdir -p "$SANDBOX_REPO"
+  (
+    cd "$SANDBOX_REPO"
+    git init -q
+    echo "hello" > README.md
+    git add README.md
+    git commit -q -m "initial"
+    echo "change" >> README.md
+    echo "untracked" > new.txt
+  )
+fi
+
+cat <<EOF
+scm_breeze sandbox — git + scm_breeze only, no other shell config.
+  /workspace        bind-mounted repo (host edits are live)
+  ~/sandbox-repo    throwaway git repo with staged/unstaged/untracked changes
+  zsh               run \`zsh\` to switch shells
+  tests             cd /workspace && ./run_tests.sh
+EOF
+
+exec "$@"

--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -110,6 +110,8 @@ git_apply_alias="gapp"
 git_switch_alias="gsw"
 git_restore_alias="grt"
 git_worktree_alias="gwt"
+git_worktree_add_alias="gwta"
+git_worktree_remove_alias="gwtr"
 # Hub aliases (https://github.com/github/hub)
 git_pull_request_alias="gpr"
 

--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -109,6 +109,7 @@ git_whatchanged_alias="gwc"
 git_apply_alias="gapp"
 git_switch_alias="gsw"
 git_restore_alias="grt"
+git_worktree_alias="gwt"
 # Hub aliases (https://github.com/github/hub)
 git_pull_request_alias="gpr"
 

--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -110,6 +110,12 @@ git_apply_alias="gapp"
 git_switch_alias="gsw"
 git_restore_alias="grt"
 git_worktree_alias="gwt"
+# Controls where `gwt add <name>` places the new worktree.
+#   ""           (default) - pass through to native `git worktree add`
+#   "sibling"              - create "<repo-basename>-<name>" next to the repo
+#   "/some/dir"            - create "/some/dir/<repo-basename>-<name>"
+# In all non-empty modes the new branch is named <name>.
+git_worktree_directory=""
 git_worktree_add_alias="gwta"
 git_worktree_remove_alias="gwtr"
 # Hub aliases (https://github.com/github/hub)

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -31,11 +31,11 @@ function git(){
     commit|blame|add|log|rebase|merge|difftool|switch)
       exec_scmb_expand_args "$_git_cmd" "$@";;
     checkout)
-      _scmb_git_checkout_shortcuts "${@:2}";;
+      __scmb_git_checkout_shortcuts "${@:2}";;
     diff|rm|reset|restore)
       exec_scmb_expand_args --relative "$_git_cmd" "$@";;
     branch)
-      _scmb_git_branch_shortcuts "${@:2}";;
+      __scmb_git_branch_shortcuts "${@:2}";;
     *)
       "$_git_cmd" "$@";;
   esac

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -163,6 +163,7 @@ if [ "$GIT_SETUP_ALIASES" = "yes" ]; then
   __git_alias "$git_whatchanged_alias"              'git' 'whatchanged'
   __git_alias "$git_apply_alias"                    'git' 'apply'
   __git_alias "$git_switch_alias"                   'git' 'switch'
+  __git_alias "$git_worktree_alias"                 'git' 'worktree'
 
   # Compound/complex commands
   _alias "$git_fetch_all_alias"           'git fetch --all'

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -164,6 +164,8 @@ if [ "$GIT_SETUP_ALIASES" = "yes" ]; then
   __git_alias "$git_apply_alias"                    'git' 'apply'
   __git_alias "$git_switch_alias"                   'git' 'switch'
   __git_alias "$git_worktree_alias"                 'git' 'worktree'
+  __git_alias "$git_worktree_add_alias"             'git' 'worktree' 'add'
+  __git_alias "$git_worktree_remove_alias"          'git' 'worktree' 'remove'
 
   # Compound/complex commands
   _alias "$git_fetch_all_alias"           'git fetch --all'

--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -24,14 +24,15 @@ if type hub > /dev/null 2>&1; then export _git_cmd="hub"; fi
 # gh is now deprecated, and merged into the `hub` command line tool.
 #if type gh  > /dev/null 2>&1; then export _git_cmd="gh"; fi
 
-# Create 'git' function that calls hub if defined, and expands all numeric arguments
-function git(){
+function __scmb_git(){
   # Only expand args for git commands that deal with paths or branches
   case $1 in
     commit|blame|add|log|rebase|merge|difftool|switch)
       exec_scmb_expand_args "$_git_cmd" "$@";;
     checkout)
       __scmb_git_checkout_shortcuts "${@:2}";;
+    worktree)
+      __scmb_git_worktree_shortcuts "${@:2}";;
     diff|rm|reset|restore)
       exec_scmb_expand_args --relative "$_git_cmd" "$@";;
     branch)
@@ -40,6 +41,8 @@ function git(){
       "$_git_cmd" "$@";;
   esac
 }
+
+function git(){ __scmb_git "$@"; }
 
 _alias "$git_alias" "git"
 

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -11,7 +11,7 @@
 # Function wrapper around 'll'
 # Adds numbered shortcuts to output of ls -l, just like 'git status'
 unalias $git_branch_alias > /dev/null 2>&1; unset -f $git_branch_alias > /dev/null 2>&1
-function _scmb_git_branch_shortcuts {
+function __scmb_git_branch_shortcuts {
   fail_if_not_git_repo || return 1
 
   # Fall back to normal git branch, if any unknown args given
@@ -41,7 +41,7 @@ EOF
   done
 }
 
-function _scmb_git_checkout_shortcuts {
+function __scmb_git_checkout_shortcuts {
   fail_if_not_git_repo || return 1
 
   if [ -z "$1" ]; then
@@ -75,11 +75,11 @@ function _scmb_git_checkout_shortcuts {
   exec_scmb_expand_args $_git_cmd checkout "$@"
 }
 
-__git_alias "$git_branch_alias"              "_scmb_git_branch_shortcuts" ""
-__git_alias "$git_branch_all_alias"          "_scmb_git_branch_shortcuts" "-a"
-__git_alias "$git_branch_move_alias"         "_scmb_git_branch_shortcuts" "-m"
-__git_alias "$git_branch_delete_alias"       "_scmb_git_branch_shortcuts" "-d"
-__git_alias "$git_branch_delete_force_alias" "_scmb_git_branch_shortcuts" "-D"
+__git_alias "$git_branch_alias"              "__scmb_git_branch_shortcuts" ""
+__git_alias "$git_branch_all_alias"          "__scmb_git_branch_shortcuts" "-a"
+__git_alias "$git_branch_move_alias"         "__scmb_git_branch_shortcuts" "-m"
+__git_alias "$git_branch_delete_alias"       "__scmb_git_branch_shortcuts" "-d"
+__git_alias "$git_branch_delete_force_alias" "__scmb_git_branch_shortcuts" "-D"
 
 # Define completions for git branch shortcuts
 if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -49,25 +49,25 @@ function _scmb_git_checkout_shortcuts {
     return $?
   fi
 
+  # If only branch then check if it's a worktree
   if [[ "$1" =~ ^[0-9]+$ ]]; then
     local branch_var="${git_env_char}$1"
-    local branch=$(eval echo "\$$branch_var")
+    local branch=$(exec_scmb_expand_args echo "${branch_var}")
 
     if [ -n "$branch" ]; then
-      if $_git_cmd worktree list --porcelain 2>/dev/null | grep -q "^branch refs/heads/$branch$"; then
-        local worktree_path=$($_git_cmd worktree list --porcelain | awk "
-          /^worktree / {
-            path = substr(\$0, 10); next
-          }
-          /^branch refs\/heads\/$branch$/ {
-            print path; exit
-          }
-        ")
-        if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
-          echo "Switching to worktree: $worktree_path"
-          cd "$worktree_path"
-          return $?
-        fi
+      local worktree_path=$($_git_cmd worktree list --porcelain 2>/dev/null | awk -v target_branch="$branch" '
+        /^worktree / { path = substr($0, 10); next }
+        /^branch / {
+          ref = substr($0, 8)
+          sub(/^refs\/heads\//, "", ref)
+          if (ref == target_branch) { print path; exit }
+        }
+      ')
+
+      if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
+        echo "Switching to worktree: $worktree_path"
+        cd "$worktree_path"
+        return $?
       fi
     fi
   fi

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -72,7 +72,7 @@ function __scmb_git_checkout_shortcuts {
     fi
   fi
 
-  exec_scmb_expand_args $_git_cmd checkout "$@"
+  _safe_eval "$_git_cmd" checkout "${args[@]}"
 }
 
 __git_alias "$git_branch_alias"              "__scmb_git_branch_shortcuts" ""

--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -41,6 +41,18 @@ EOF
   done
 }
 
+function __scmb_git_worktree_path_for_branch {
+  local target_branch="$1"
+  $_git_cmd worktree list --porcelain 2>/dev/null | awk -v target_branch="$target_branch" '
+    /^worktree / { path = substr($0, 10); next }
+    /^branch / {
+      ref = substr($0, 8)
+      sub(/^refs\/heads\//, "", ref)
+      if (ref == target_branch) { print path; exit }
+    }
+  '
+}
+
 function __scmb_git_checkout_shortcuts {
   fail_if_not_git_repo || return 1
 
@@ -49,20 +61,15 @@ function __scmb_git_checkout_shortcuts {
     return $?
   fi
 
-  # If only branch then check if it's a worktree
-  if [[ "$1" =~ ^[0-9]+$ ]]; then
-    local branch_var="${git_env_char}$1"
-    local branch=$(exec_scmb_expand_args echo "${branch_var}")
+  local args
+  eval "args=$(scmb_expand_args "$@")"
 
-    if [ -n "$branch" ]; then
-      local worktree_path=$($_git_cmd worktree list --porcelain 2>/dev/null | awk -v target_branch="$branch" '
-        /^worktree / { path = substr($0, 10); next }
-        /^branch / {
-          ref = substr($0, 8)
-          sub(/^refs\/heads\//, "", ref)
-          if (ref == target_branch) { print path; exit }
-        }
-      ')
+  # If a single, non-flag branch arg is given, check if it lives in a worktree.
+  if [ "${#args[@]}" -eq 1 ]; then
+    local branch="${args[@]}"
+
+    if __scmb_is_plain_name "$branch"; then
+      local worktree_path=$(__scmb_git_worktree_path_for_branch "$branch")
 
       if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
         echo "Switching to worktree: $worktree_path"
@@ -72,7 +79,86 @@ function __scmb_git_checkout_shortcuts {
     fi
   fi
 
-  _safe_eval "$_git_cmd" checkout "${args[@]}"
+  __safe_eval "$_git_cmd" checkout "${args[@]}"
+}
+
+# Compute where `git worktree add <name>` should place its directory, based on
+# $git_worktree_directory. Prints the chosen path; returns non-zero on bad config.
+function __scmb_git_worktree_target_path {
+  local name="$1"
+  local repo_root parent base dir_name path
+  repo_root=$($_git_cmd rev-parse --show-toplevel) || return 1
+  parent="$(dirname "$repo_root")"
+  base="$(basename "$repo_root")"
+  dir_name="${name//\//-}"   # sanitize only the directory portion; keep branch name intact
+
+  case "$git_worktree_directory" in
+    # 'sibling': worktree '<repo>-<name>' placed next to the repo.
+    # To omit the repo basename use '..' instead (or an absolute path).
+    sibling)
+      path="$parent/$base-$dir_name"
+      ;;
+    # 'feature': directory '<name>' next to the repo, with the repo's worktree
+    # nested inside. Lets a feature span multiple repos under one '<name>' dir.
+    feature)
+      mkdir -p "$parent/$dir_name"
+      path="$parent/$dir_name/$base"
+      ;;
+    # otherwise: an explicit existing directory to drop '<repo>-<name>' into.
+    *)
+      if [ -d "$git_worktree_directory" ]; then
+        path="${git_worktree_directory%/}/$base-$dir_name"
+      else
+        echo "scm_breeze: git_worktree_directory '$git_worktree_directory' is not 'sibling' or an existing directory" >&2
+        return 1
+      fi
+      ;;
+  esac
+
+  printf '%s\n' "$path"
+}
+
+# `git worktree add <name>` honoring $git_worktree_directory placement.
+# Creates a new branch when one named <name> doesn't already exist.
+function __scmb_git_worktree_add {
+  local name="$1" path
+  path=$(__scmb_git_worktree_target_path "$name") || return 1
+
+  if $_git_cmd show-ref --verify --quiet "refs/heads/$name"; then
+    __safe_eval "$_git_cmd" worktree add "$path" "$name"
+  else
+    __safe_eval "$_git_cmd" worktree add -b "$name" "$path"
+  fi
+}
+
+function __scmb_git_worktree_shortcuts {
+  fail_if_not_git_repo || return 1
+
+  # Expand numbered shortcuts (e.g. `1` -> `$e1`) so `gwtr 1`, `gwta 1`, etc. work.
+  # Reset positional params from the expanded array so the rest of the function
+  # can keep using $1/$2/$#/"$@" portably across bash and zsh.
+  local args
+  eval "args=$(scmb_expand_args "$@")"
+  set -- "${args[@]}"
+
+  # `gwt remove <branch>`: translate a branch name to its worktree path so remove
+  # works by branch. Fall through to native git if no worktree matches that name.
+  if [ "$1" = "remove" ] && [ "$#" -eq 2 ] && __scmb_is_plain_name "$2"; then
+    local worktree_path=$(__scmb_git_worktree_path_for_branch "$2")
+    if [ -n "$worktree_path" ]; then
+      __safe_eval "$_git_cmd" worktree remove "$worktree_path"
+      return $?
+    fi
+  fi
+
+  # `gwt add <name>`: place the worktree per $git_worktree_directory instead of
+  # native git's default.
+  if [ "$1" = "add" ] && [ -n "$git_worktree_directory" ] && [ "$#" -eq 2 ] && __scmb_is_plain_name "$2"; then
+    __scmb_git_worktree_add "$2"
+    return $?
+  fi
+
+  __safe_eval "$_git_cmd" worktree "$@"
 }
 
 __git_alias "$git_branch_alias"              "__scmb_git_branch_shortcuts" ""

--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -31,7 +31,7 @@ git_status_shortcuts() {
     if [ -d .git ]; then
       local project_root="$PWD"
     else
-      local project_root=$(git rev-parse --git-dir 2> /dev/null | sed "s%/\.git$%%g")
+      local project_root=$(git rev-parse --show-toplevel 2> /dev/null)
     fi
 
     # Colors

--- a/lib/git/helpers.sh
+++ b/lib/git/helpers.sh
@@ -8,6 +8,11 @@ function fail_if_not_git_repo() {
   return 0
 }
 
+# True when $1 is a non-empty, non-flag argument (a plain branch/worktree name).
+function __scmb_is_plain_name() {
+  [ -n "$1" ] && [ "${1#-}" = "$1" ]
+}
+
 bin_path() {
   if [[ -n ${ZSH_VERSION:-} ]];
     then builtin whence -cp "$1" 2> /dev/null

--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -184,8 +184,8 @@ _print_path() {
 # Fails if command is a number or range (probably not worth fixing)
 exec_scmb_expand_args() {
   local args
-  eval "args=$(scmb_expand_args "$@")" # populate $args array
-  _safe_eval "${args[@]}"
+  eval "args=$(scmb_expand_args "$@")"  # populate $args array
+  __safe_eval "${args[@]}"
 }
 
 # Clear numbered env variables

--- a/lib/scm_breeze.sh
+++ b/lib/scm_breeze.sh
@@ -79,7 +79,7 @@ function token_quote {
 # Quote "$@" before `eval` to prevent arbitrary code execution.
 # Eg, the following will run `date`:
 # evil() { eval "$@"; }; evil "echo" "foo;date"
-function _safe_eval() {
+function __safe_eval() {
   eval $(token_quote "$@")
 
   # Keep this code for use when minimum versions of {ba,z}sh can be increased.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+### Problem
+I think that there should be more cats in the code.
+
+### What
+- Added 10% more cats to the code
+
+### Why
+- With more cats in the code there is more pleasant meowing

--- a/test/lib/scm_breeze_test.sh
+++ b/test/lib/scm_breeze_test.sh
@@ -16,9 +16,9 @@ source "$scmbDir/lib/scm_breeze.sh"
 #-----------------------------------------------------------------------------
 
 test__safe_eval() {
-  assertEquals "runs eval with simple words" 'one two three' "$(_safe_eval token_quote one two three)"
-  assertEquals "quotes spaces" 'a b\ c d' "$(_safe_eval token_quote a b\ c d)"
-  assertEquals "quotes special chars" 'a\ b \$dollar \\slash c\ d' "$(_safe_eval token_quote a\ b '$dollar' '\slash' c\ d)"
+  assertEquals "runs eval with simple words" 'one two three' "$(__safe_eval token_quote one two three)"
+  assertEquals "quotes spaces" 'a b\ c d' "$(__safe_eval token_quote a b\ c d)"
+  assertEquals "quotes special chars" 'a\ b \$dollar \\slash c\ d' "$(__safe_eval token_quote a\ b '$dollar' '\slash' c\ d)"
 }
 
 


### PR DESCRIPTION
#### Problem
I wanted to get git worktrees into an scm breez-ish way and along the way I found a bug-ish thing in interactions between ClaudeCode and scm breeze and also added some niceties to the repo.

#### What
- Full worktree support in scm breezish way - `gwt` `gwta` `gwtr` aliases, you can pass `gco 2` and it knows to cd to the directory for you
- Concept of worktree `sibling` or `feature` or just a different directory you want as default instead of `git` defaulting to directory you're in (more documentation near the setting in code)
- Non-private `_` fns moved to `__` to help with a ClaudeCode quirk
- Docker 'testing' helper so I could isolate from my local scrips more easily - helps with multiple shell types (bash and zsh) testing
- Pulled in an outstanding fix for `git rev-parse --show-toplevel`
- Fixed several worktree bugs in scm breeze, ie. #364 is accidentally fixed by my refactors and I also intentionally fixed where a `/` in the name didn't work correctly.

#### Why
- I'm using worktrees more with ai and I love scm breeze features/shortcuts etc
- I'm annoyed with worktree default of being in the current directory - it just isn't how my brain wants it organized and thought maybe others felt this way
- I spent a lot of time debugging ClaudeCode not being able to call my `ls` and `cat` because I wrapped in the super helpful `_scmb_git_branch_shortcuts` but ClaudeCode ignores all single `_` fns and it caused a lot of pain so I renamed _only_ the fns that are used in a non-private way to have `__` in front.
- I was having trouble testing local b/c I couldn't tell if a quirk was in my extra shell fns or in scm breeze so created a docker tester to help - also helpful it supports bash and zsh so you can easily test different shells
- I just saw #365 and seemed reasonable to pull in to my fork
- Bugs are annoying!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Docker sandbox for trying the tool in an isolated environment, with build/run instructions and an included shell session.
  * Added shortcuts for working with git worktrees, including creating, removing, and switching more naturally between branches and their worktrees.
* **Bug Fixes**
  * Improved path handling for status-related shortcuts so file paths resolve from the correct project root.
* **Documentation**
  * Expanded the README with a new Docker sandbox section.
* **Tests**
  * Updated coverage to match the improved command evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->