### PR TITLE
bash: fix completions when lazy loaded

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -187,7 +187,6 @@ if [ "$GIT_SETUP_ALIASES" = "yes" ]; then
   _alias "$git_pull_request_alias"        'gh pr'
 fi
 
-# TODO(ghthor): apply these same fixes for NixOS
 # Tab completion
 if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
   if breeze_shell_is "bash"; then
@@ -195,6 +194,8 @@ if [ "$GIT_SKIP_SHELL_COMPLETION" != "yes" ]; then
     [[ -s "/usr/share/git/completion/git-completion.bash" ]] && source "/usr/share/git/completion/git-completion.bash"
     # new path in Ubuntu 13.04
     [[ -s "/usr/share/bash-completion/completions/git" ]] && source "/usr/share/bash-completion/completions/git"
+    # NixOS / nix-managed bash-completion uses lazy loading; force-load git completion now
+    type _completion_loader &>/dev/null && _completion_loader git
     complete -o default -o nospace -F __git_wrap__git_main $git_alias
 
     # Git repo management & aliases.


### PR DESCRIPTION
### Problem

Bash tab completion from aliases before `git` completions have loaded cause errors like this.

```
 g <TAB>bash: completion: function `__git_wrap__git_main' not found
```

Manually fixed by forcing the `git` completions to load at the shell prompt with this.

```
git <TAB>
```

### What

Add an explicit loading of the git shell completions

### Why

So this just works w/o needing a manual fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git tab completion in NixOS and other Nix-managed environments by ensuring Git’s shell completion loads when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->